### PR TITLE
Add OpenSSL "minimum useless engine" example

### DIFF
--- a/mue/BUILD
+++ b/mue/BUILD
@@ -1,0 +1,21 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "engine",
+    srcs = ["engine.c"],
+)

--- a/mue/BUILD
+++ b/mue/BUILD
@@ -18,4 +18,5 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "engine",
     srcs = ["engine.c"],
+    linkopts = ["-lcrypto"],
 )

--- a/mue/README.md
+++ b/mue/README.md
@@ -1,0 +1,14 @@
+# Minimum Useless Engine
+
+A "minimum useless engine" for OpenSSL based on [this tutorial][tutorial].
+
+## Usage
+
+From within the `mue` directory:
+
+```bash
+bazel build engine
+openssl engine -t -c `pwd`/../bazel-bin/mue/libengine.so
+```
+
+[tutorial]: https://www.openssl.org/blog/blog/2015/10/08/engine-building-lesson-1-a-minimum-useless-engine/

--- a/mue/engine.c
+++ b/mue/engine.c
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include <openssl/engine.h>
-#include "wrapper.h"
 
 static const char *engine_id = "mue";
 static const char *engine_name = "A minimum engine";

--- a/mue/engine.c
+++ b/mue/engine.c
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <openssl/engine.h>
+#include "wrapper.h"
+
+static const char *engine_id = "mue";
+static const char *engine_name = "A minimum engine";
+
+static int bind(ENGINE *e, const char *id)
+{
+    if (!ENGINE_set_id(e, engine_id)) {
+        fprintf(stderr, "ENGINE_set_id failed\n");
+        return 0;
+    }
+    if (!ENGINE_set_name(e, engine_name)) {
+        printf("ENGINE_set_name failed\n");
+        return 0;
+    }
+
+    return 1;
+}
+
+IMPLEMENT_DYNAMIC_BIND_FN(bind);
+IMPLEMENT_DYNAMIC_CHECK_FN();


### PR DESCRIPTION
Adds example code for a "minimum useless engine" (MUE) for OpenSSL. Resolves #3. 

As a warning, the Bazel `BUILD` file will probably need to be changed at some point, since the MUE tutorial specifies that the `libcrypto.so` library should be linked with the `-lcrypto` flag passed to `gcc`. I don't think this is being done anywhere implicitly in `BUILD`, but the library still works. It might also be a flag that the tutorial specifies that actually isn't necessary for a "minimum" engine.

### References

- https://www.openssl.org/blog/blog/2015/10/08/engine-building-lesson-1-a-minimum-useless-engine/