### PR TITLE
Add sh_test to check OpenSSL CLI can dynamically load engine

### DIFF
--- a/test/openssl_cli/BUILD
+++ b/test/openssl_cli/BUILD
@@ -1,0 +1,29 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package(default_testonly = True)
+
+# sh_test rules cannot refer to non-sh_library or non-sh_binary dependencies in
+# the `deps` field. Thus, we include libengine.so as a `data` dependency. Then,
+# using Bazel's `rootpath` make variable, we retrieve the data path of
+# libengine.so and pass the path to the shell script as an argument via `args`.
+sh_test(
+    name = "load_engine_test",
+    size = "small",
+    srcs = ["load_engine_test.sh"],
+    args = ["$(rootpath //src/bridge:libengine.so)"],
+    data = ["//src/bridge:libengine.so"],
+)

--- a/test/openssl_cli/load_engine_test.sh
+++ b/test/openssl_cli/load_engine_test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Checks that the OpenSSL CLI is able to dynamically load the engine without
+# error. Success when exit code of script is 0.
+
+set -eu
+
+# Passed from Bazel `args` on sh_test target.
+LIBENGINE_REL_PATH="${1}"
+
+# OpenSSL requires the path to the engine to be absolute.
+LIBENGINE_ABS_PATH="$(realpath "${LIBENGINE_REL_PATH}")"
+
+openssl engine -t "${LIBENGINE_ABS_PATH}"


### PR DESCRIPTION
Resolves #29.

This is almost the same PR as #31 but with the `src/engine` path in the test `BUILD` file changed to `src/bridge`. Remade the PR due to some git issues that I didn't want to get too stuck on since the PR is small anyways.