### PR TITLE
Add Cloud Build configuration.

### DIFF
--- a/bazel_build.sh
+++ b/bazel_build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Fail on any error.
+set -e
+# Treat unset variables an error.
+set -u
+# Print commands as executed.
+set -x
+
+apt-get update
+
+# Install a system-wide OpenSSL headers.
+apt-get -y install libssl-dev
+
+apt-get -y install  software-properties-common
+add-apt-repository ppa:git-core/ppa
+apt-get -y update
+apt-get -y install git
+
+apt-get -y install \
+  apt-transport-https \
+  curl \
+  gnupg2 \
+  ca-certificates \
+  openjdk-8-jdk
+echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+curl https://bazel.build/bazel-release.pub.gpg | apt-key add - 
+apt-get update
+apt-get -y install bazel
+apt-get -y upgrade bazel
+
+bazel test ... \
+  --verbose_failures=true \
+  --test_output=errors \
+
+exit 0

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,3 @@
+steps:
+- name: 'ubuntu'
+  args: ['bash', 'bazel_build.sh']


### PR DESCRIPTION
Fixes #8 

Some notes

- The container installs the OpenSSL headers at the system level.
- We can't use the Bazel container, because Bazel doesn't have access to bash or other command line tools.
- The installation scripts take a long time to run. If we want shorter run times, we can set up a custom container with the dev environment already set up.