### PR TITLE
Define native Client interface for AsymmetricSign

### DIFF
--- a/src/backing/client/BUILD
+++ b/src/backing/client/BUILD
@@ -1,0 +1,97 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//src:__subpackages__"])
+
+filegroup(
+    name = "headers",
+    srcs = glob(["**/*.h"]),
+)
+
+cc_library(
+    name = "client",
+    hdrs = ["client.h"],
+    deps = [
+        ":asymmetric_sign_request",
+        ":asymmetric_sign_response",
+        ":digest",
+        ":digest_type",
+    ],
+)
+
+cc_library(
+    name = "asymmetric_sign_request",
+    hdrs = "asymmetric_sign_request.h",
+    deps = [":digest"],
+)
+
+cc_test(
+    name = "asymmetric_sign_request_test",
+    hdrs = "asymmetric_sign_request_test.cc",
+    size = "small",
+    deps = [
+        ":asymmetric_sign_request",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "asymmetric_sign_response",
+    hdrs = "asymmetric_sign_response.h",
+)
+
+cc_test(
+    name = "asymmetric_sign_response_test",
+    hdrs = "asymmetric_sign_response_test.cc",
+    size = "small",
+    deps = [
+        ":asymmetric_sign_response",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "digest",
+    hdrs = "digest.h",
+    deps = [":digest_type"],
+)
+
+cc_test(
+    name = "digest_test",
+    hdrs = "digest_test.cc",
+    size = "small",
+    deps = [
+        ":digest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "digest_type",
+    hdrs = "digest_type.h",
+)
+
+cc_test(
+    name = "digest_type_test",
+    hdrs = "digest_type_test.cc",
+    size = "small",
+    deps = [
+        ":digest_type",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/backing/client/BUILD
+++ b/src/backing/client/BUILD
@@ -1,0 +1,92 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//src:__subpackages__"])
+
+filegroup(
+    name = "headers",
+    srcs = glob(["**/*.h"]),
+)
+
+cc_library(
+    name = "client",
+    hdrs = ["client.h"],
+    deps = [":service"],
+)
+
+cc_library(
+    name = "asymmetric_sign_request",
+    hdrs = "asymmetric_sign_request.h",
+    deps = [":digest"],
+)
+
+cc_test(
+    name = "asymmetric_sign_request_test",
+    hdrs = "asymmetric_sign_request_test.cc",
+    size = "small",
+    deps = [
+        ":asymmetric_sign_request",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "asymmetric_sign_response",
+    hdrs = "asymmetric_sign_response.h",
+)
+
+cc_test(
+    name = "asymmetric_sign_response_test",
+    hdrs = "asymmetric_sign_response_test.cc",
+    size = "small",
+    deps = [
+        ":asymmetric_sign_response",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "digest",
+    hdrs = "digest.h",
+    deps = [":digest_type"],
+)
+
+cc_test(
+    name = "digest_test",
+    hdrs = "digest_test.cc",
+    size = "small",
+    deps = [
+        ":digest",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "digest_type",
+    hdrs = "digest_type.h",
+)
+
+cc_test(
+    name = "digest_type_test",
+    hdrs = "digest_type_test.cc",
+    size = "small",
+    deps = [
+        ":digest_type",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/backing/client/BUILD
+++ b/src/backing/client/BUILD
@@ -18,32 +18,25 @@ load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 
 package(default_visibility = ["//src:__subpackages__"])
 
-filegroup(
-    name = "headers",
-    srcs = glob(["**/*.h"]),
-)
-
 cc_library(
     name = "client",
     hdrs = ["client.h"],
     deps = [
         ":asymmetric_sign_request",
         ":asymmetric_sign_response",
-        ":digest",
-        ":digest_type",
     ],
 )
 
 cc_library(
     name = "asymmetric_sign_request",
-    hdrs = "asymmetric_sign_request.h",
+    hdrs = ["asymmetric_sign_request.h"],
     deps = [":digest"],
 )
 
 cc_test(
     name = "asymmetric_sign_request_test",
-    hdrs = "asymmetric_sign_request_test.cc",
     size = "small",
+    srcs = ["asymmetric_sign_request_test.cc"],
     deps = [
         ":asymmetric_sign_request",
         "@com_google_googletest//:gtest_main",
@@ -52,13 +45,13 @@ cc_test(
 
 cc_library(
     name = "asymmetric_sign_response",
-    hdrs = "asymmetric_sign_response.h",
+    hdrs = ["asymmetric_sign_response.h"],
 )
 
 cc_test(
     name = "asymmetric_sign_response_test",
-    hdrs = "asymmetric_sign_response_test.cc",
     size = "small",
+    srcs = ["asymmetric_sign_response_test.cc"],
     deps = [
         ":asymmetric_sign_response",
         "@com_google_googletest//:gtest_main",
@@ -67,14 +60,14 @@ cc_test(
 
 cc_library(
     name = "digest",
-    hdrs = "digest.h",
+    hdrs = ["digest.h"],
     deps = [":digest_type"],
 )
 
 cc_test(
     name = "digest_test",
-    hdrs = "digest_test.cc",
     size = "small",
+    srcs = ["digest_test.cc"],
     deps = [
         ":digest",
         "@com_google_googletest//:gtest_main",
@@ -83,15 +76,17 @@ cc_test(
 
 cc_library(
     name = "digest_type",
-    hdrs = "digest_type.h",
+    hdrs = ["digest_type.h"],
 )
 
 cc_test(
     name = "digest_type_test",
-    hdrs = "digest_type_test.cc",
     size = "small",
+    srcs = ["digest_type_test.cc"],
     deps = [
         ":digest_type",
+        "@com_google_googleapis//:googleapis_system_includes",
+        "@com_google_googleapis//google/cloud/kms/v1:kms_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/src/backing/client/asymmetric_sign_request.h
+++ b/src/backing/client/asymmetric_sign_request.h
@@ -36,8 +36,8 @@ class AsymmetricSignRequest {
       : key_name_(std::move(key_name)),
         digest_(std::move(digest)) {}
 
-  std::string const& KeyName() const { return key_name_; }
-  Digest const& Digest() const { return digest_; }
+  std::string const& key_name() const { return key_name_; }
+  Digest const& digest() const { return digest_; }
 
  private:
   std::string key_name_;

--- a/src/backing/client/asymmetric_sign_request.h
+++ b/src/backing/client/asymmetric_sign_request.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BACKING_CLIENT_ASYMMETRIC_SIGN_REQUEST_H_
+#define KMSENGINE_BACKING_CLIENT_ASYMMETRIC_SIGN_REQUEST_H_
+
+#include <string>
+#include <utility>
+
+#include "src/backing/client/digest.h"
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+
+// Represents metadata for a AsymmetricSignRequest from the Key Management
+// Service API.
+class AsymmetricSignRequest {
+ public:
+  // `key_name` is the resource name of the google.cloud.kms.v1.CryptoKeyVersion
+  // to use for signing. `digest` holds the digest of the data to sign.
+  AsymmetricSignRequest(std::string key_name, Digest digest)
+      : key_name_(std::move(key_name)),
+        digest_(std::move(digest)) {}
+
+  std::string const& KeyName() const { return key_name_; }
+  Digest const& Digest() const { return digest_; }
+
+ private:
+  std::string key_name_;
+  Digest digest_;
+};
+
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BACKING_CLIENT_ASYMMETRIC_SIGN_REQUEST_H_

--- a/src/backing/client/asymmetric_sign_request_test.cc
+++ b/src/backing/client/asymmetric_sign_request_test.cc
@@ -27,9 +27,9 @@ namespace {
 TEST(AsymmetricSignRequestTest, ConstructorSetsExpectedFields) {
   Digest digest(DigestType::kSha256, "some-digest");
   AsymmetricSignRequest request("my-key-name", digest);
-  EXPECT_EQ(request.KeyName(), "my-key-name");
-  EXPECT_EQ(request.Digest().Type(), DigestType::kSha256);
-  EXPECT_EQ(request.Digest().Bytes(), "some-digest");
+  EXPECT_EQ(request.key_name(), "my-key-name");
+  EXPECT_EQ(request.digest().type(), DigestType::kSha256);
+  EXPECT_EQ(request.digest().bytes(), "some-digest");
 }
 
 }  // namespace

--- a/src/backing/client/asymmetric_sign_request_test.cc
+++ b/src/backing/client/asymmetric_sign_request_test.cc
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/backing/client/asymmetric_sign_request.h"
+#include "src/backing/client/digest.h"
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+namespace {
+
+TEST(AsymmetricSignRequestTest, ConstructorSetsExpectedFields) {
+  Digest digest(DigestType::kSha256, "some-digest");
+  AsymmetricSignRequest request("my-key-name", digest);
+  EXPECT_EQ(request.KeyName(), "my-key-name");
+  EXPECT_EQ(request.Digest().Type(), DigestType::kSha256);
+  EXPECT_EQ(request.Digest().Bytes(), "some-digest");
+}
+
+}  // namespace
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine

--- a/src/backing/client/asymmetric_sign_response.h
+++ b/src/backing/client/asymmetric_sign_response.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BACKING_CLIENT_ASYMMETRIC_SIGN_RESPONSE_H_
+#define KMSENGINE_BACKING_CLIENT_ASYMMETRIC_SIGN_RESPONSE_H_
+
+#include <string>
+#include <utility>
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+
+// Represents metadata for a AsymmetricSignResponse from the Key Management
+// Service API.
+class AsymmetricSignResponse {
+ public:
+  AsymmetricSignResponse(std::string signature)
+      : signature_(std::move(signature)) {}
+
+  std::string const& Signature() const { return signature_; }
+
+ private:
+  std::string signature_;
+};
+
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BACKING_CLIENT_ASYMMETRIC_SIGN_RESPONSE_H_

--- a/src/backing/client/asymmetric_sign_response.h
+++ b/src/backing/client/asymmetric_sign_response.h
@@ -31,7 +31,7 @@ class AsymmetricSignResponse {
   AsymmetricSignResponse(std::string signature)
       : signature_(std::move(signature)) {}
 
-  std::string const& Signature() const { return signature_; }
+  std::string const& signature() const { return signature_; }
 
  private:
   std::string signature_;

--- a/src/backing/client/asymmetric_sign_response_test.cc
+++ b/src/backing/client/asymmetric_sign_response_test.cc
@@ -25,7 +25,7 @@ namespace {
 
 TEST(AsymmetricSignResponseTest, ConstructorSetsExpectedFields) {
   AsymmetricSignResponse response("my-signature");
-  EXPECT_STREQ(response.Signature(), "my-signature");
+  EXPECT_EQ(response.signature(), "my-signature");
 }
 
 }  // namespace

--- a/src/backing/client/asymmetric_sign_response_test.cc
+++ b/src/backing/client/asymmetric_sign_response_test.cc
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/backing/client/asymmetric_sign_response.h"
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+namespace {
+
+TEST(AsymmetricSignResponseTest, ConstructorSetsExpectedFields) {
+  AsymmetricSignResponse response("my-signature");
+  EXPECT_STREQ(response.Signature(), "my-signature");
+}
+
+}  // namespace
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine

--- a/src/backing/client/client.h
+++ b/src/backing/client/client.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef KMSENGINE_BACKING_CLIENT_API_CLIENT_H_
-#define KMSENGINE_BACKING_CLIENT_API_CLIENT_H_
+#ifndef KMSENGINE_BACKING_CLIENT_CLIENT_H_
+#define KMSENGINE_BACKING_CLIENT_CLIENT_H_
 
 #include "src/backing/client/asymmetric_sign_request.h"
 #include "src/backing/client/asymmetric_sign_response.h"
@@ -43,4 +43,4 @@ class Client {
 }  // namespace backing
 }  // namespace kmsengine
 
-#endif  // KMSENGINE_BACKING_CLIENT_API_CLIENT_H_
+#endif  // KMSENGINE_BACKING_CLIENT_CLIENT_H_

--- a/src/backing/client/client.h
+++ b/src/backing/client/client.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BACKING_CLIENT_API_CLIENT_H_
+#define KMSENGINE_BACKING_CLIENT_API_CLIENT_H_
+
+#include "src/backing/client/asymmetric_sign_request.h"
+#include "src/backing/client/asymmetric_sign_response.h"
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+
+// Defines the interface used to communicate with the Google Cloud KMS API.
+class Client {
+ public:
+  virtual ~Client() = 0;
+
+  // Signs data using the CryptoKeyVersion with name
+  // `AsymmetricSignRequest::KeyName()`. Produces a signature that can be
+  // verified with the public key retrieved from `GetPublicKey`.
+  //
+  // The CryptoKeyVersion must have CryptoKey.purpose ASYMMETRIC_SIGN. If not,
+  // an error status is returned.
+  virtual StatusOr<AsymmetricSignResponse> AsymmetricSign(
+      AsymmetricSignRequest const& request) = 0;
+};
+
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BACKING_CLIENT_API_CLIENT_H_

--- a/src/backing/client/client.h
+++ b/src/backing/client/client.h
@@ -19,6 +19,7 @@
 
 #include "src/backing/client/asymmetric_sign_request.h"
 #include "src/backing/client/asymmetric_sign_response.h"
+#include "src/backing/status/status.h"
 
 namespace kmsengine {
 namespace backing {
@@ -27,7 +28,7 @@ namespace client {
 // Defines the interface used to communicate with the Google Cloud KMS API.
 class Client {
  public:
-  virtual ~Client() = 0;
+  virtual ~Client() = default;
 
   // Signs data using the CryptoKeyVersion with name
   // `AsymmetricSignRequest::KeyName()`. Produces a signature that can be

--- a/src/backing/client/digest.h
+++ b/src/backing/client/digest.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BACKING_CLIENT_DIGEST_H_
+#define KMSENGINE_BACKING_CLIENT_DIGEST_H_
+
+#include <string>
+#include <utility>
+
+#include "src/backing/client/digest_type.h"
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+
+// Represents metadata for a Digest from the Key Management Service API. Holds
+// a cryptographic message digest produced by the algorithm denoted by the
+// given DigestType.
+class Digest {
+ public:
+  Digest(DigestType type, std::string bytes) : type_(std::move(type)),
+                                               bytes_(std::move(bytes)) {}
+
+  DigestType const& Type() const { return type_; }
+  std::string const& Bytes() const { return bytes_; }
+
+ private:
+  DigestType type_;
+  std::string bytes_;
+};
+
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BACKING_CLIENT_DIGEST_H_

--- a/src/backing/client/digest.h
+++ b/src/backing/client/digest.h
@@ -34,8 +34,8 @@ class Digest {
   Digest(DigestType type, std::string bytes) : type_(std::move(type)),
                                                bytes_(std::move(bytes)) {}
 
-  DigestType const& Type() const { return type_; }
-  std::string const& Bytes() const { return bytes_; }
+  DigestType const& type() const { return type_; }
+  std::string const& bytes() const { return bytes_; }
 
  private:
   DigestType type_;

--- a/src/backing/client/digest_test.cc
+++ b/src/backing/client/digest_test.cc
@@ -25,20 +25,20 @@ namespace {
 
 TEST(DigestTest, ConstructorSetsExpectedFieldsForSha256) {
   Digest digest(DigestType::kSha256, "my-256-digest");
-  EXPECT_EQ(digest.Type(), DigestType::kSha256);
-  EXPECT_STREQ(digest.Bytes(), "my-256-digest");
+  EXPECT_EQ(digest.type(), DigestType::kSha256);
+  EXPECT_EQ(digest.bytes(), "my-256-digest");
 }
 
 TEST(DigestTest, ConstructorSetsExpectedFieldsForSha384) {
   Digest digest(DigestType::kSha384, "my-384-digest");
-  EXPECT_EQ(digest.Type(), DigestType::kSha384);
-  EXPECT_STREQ(digest.Bytes(), "my-384-digest");
+  EXPECT_EQ(digest.type(), DigestType::kSha384);
+  EXPECT_EQ(digest.bytes(), "my-384-digest");
 }
 
 TEST(DigestTest, ConstructorSetsExpectedFieldsForSha512) {
   Digest digest(DigestType::kSha512, "my-512-digest");
-  EXPECT_EQ(digest.Type(), DigestType::kSha512);
-  EXPECT_STREQ(digest.Bytes(), "my-512-digest");
+  EXPECT_EQ(digest.type(), DigestType::kSha512);
+  EXPECT_EQ(digest.bytes(), "my-512-digest");
 }
 
 }  // namespace

--- a/src/backing/client/digest_test.cc
+++ b/src/backing/client/digest_test.cc
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "src/backing/client/digest.h"
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+namespace {
+
+TEST(DigestTest, ConstructorSetsExpectedFieldsForSha256) {
+  Digest digest(DigestType::kSha256, "my-256-digest");
+  EXPECT_EQ(digest.Type(), DigestType::kSha256);
+  EXPECT_STREQ(digest.Bytes(), "my-256-digest");
+}
+
+TEST(DigestTest, ConstructorSetsExpectedFieldsForSha384) {
+  Digest digest(DigestType::kSha384, "my-384-digest");
+  EXPECT_EQ(digest.Type(), DigestType::kSha384);
+  EXPECT_STREQ(digest.Bytes(), "my-384-digest");
+}
+
+TEST(DigestTest, ConstructorSetsExpectedFieldsForSha512) {
+  Digest digest(DigestType::kSha512, "my-512-digest");
+  EXPECT_EQ(digest.Type(), DigestType::kSha512);
+  EXPECT_STREQ(digest.Bytes(), "my-512-digest");
+}
+
+}  // namespace
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine

--- a/src/backing/client/digest_type.h
+++ b/src/backing/client/digest_type.h
@@ -29,7 +29,7 @@ enum class DigestType : int {
   kSha256 = 1,
   kSha384 = 2,
   kSha512 = 3,
-}
+};
 
 }  // namespace client
 }  // namespace backing

--- a/src/backing/client/digest_type.h
+++ b/src/backing/client/digest_type.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BACKING_CLIENT_DIGEST_TYPE_H_
+#define KMSENGINE_BACKING_CLIENT_DIGEST_TYPE_H_
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+
+// Represents the algorithm used to produce a particular Digest.
+//
+// Underlying values should match the underlying values of
+// `google.cloud.kms.v1.Digest` from the API's protobuf definition.
+enum class DigestType : int {
+  kSha256 = 1,
+  kSha384 = 2,
+  kSha512 = 3,
+}
+
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BACKING_CLIENT_DIGEST_TYPE_H_

--- a/src/backing/client/digest_type_test.cc
+++ b/src/backing/client/digest_type_test.cc
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <google/cloud/kms/v1/service.pb.h>
+
+#include "src/backing/client/digest_type.h"
+
+namespace kmsengine {
+namespace backing {
+namespace client {
+namespace {
+
+using ProtoDigestCase = google::cloud::kms::v1::Digest::DigestCase;
+using DigestTypeUnderlying = std::underlying_type<DigestType>;
+
+TEST(DigestTypeTest, UnderlyingEnumValueMatchesProtoDefinitions) {
+  EXPECT_EQ(static_cast<DigestTypeUnderlying>(DigestType::kSha256),
+            ProtoDigestCase::kSha256);
+  EXPECT_EQ(static_cast<DigestTypeUnderlying>(DigestType::kSha384),
+            ProtoDigestCase::kSha384);
+  EXPECT_EQ(static_cast<DigestTypeUnderlying>(DigestType::kSha512),
+            ProtoDigestCase::kSha512);
+}
+
+}  // namespace
+}  // namespace client
+}  // namespace backing
+}  // namespace kmsengine

--- a/src/backing/client/digest_type_test.cc
+++ b/src/backing/client/digest_type_test.cc
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include <gtest/gtest.h>
 #include <google/cloud/kms/v1/service.pb.h>
+#include <gtest/gtest.h>
 
 #include "src/backing/client/digest_type.h"
 
@@ -24,16 +24,17 @@ namespace backing {
 namespace client {
 namespace {
 
+// Helper function for casting a `DigestType` to its underlying type.
+inline std::underlying_type<DigestType>::type CastDigest(DigestType digest) {
+  return static_cast<std::underlying_type<DigestType>::type>(digest);
+}
+
 using ProtoDigestCase = google::cloud::kms::v1::Digest::DigestCase;
-using DigestTypeUnderlying = std::underlying_type<DigestType>;
 
 TEST(DigestTypeTest, UnderlyingEnumValueMatchesProtoDefinitions) {
-  EXPECT_EQ(static_cast<DigestTypeUnderlying>(DigestType::kSha256),
-            ProtoDigestCase::kSha256);
-  EXPECT_EQ(static_cast<DigestTypeUnderlying>(DigestType::kSha384),
-            ProtoDigestCase::kSha384);
-  EXPECT_EQ(static_cast<DigestTypeUnderlying>(DigestType::kSha512),
-            ProtoDigestCase::kSha512);
+  EXPECT_EQ(CastDigest(DigestType::kSha256), ProtoDigestCase::kSha256);
+  EXPECT_EQ(CastDigest(DigestType::kSha384), ProtoDigestCase::kSha384);
+  EXPECT_EQ(CastDigest(DigestType::kSha512), ProtoDigestCase::kSha512);
 }
 
 }  // namespace


### PR DESCRIPTION
Part of #10 and #11.

Defines a minimal `Client` interface for making `AsymmetricSign` requests against the Cloud KMS API, along with several native definitions of request structures and resources.