### PR TITLE
Add memory utilities for making smart pointers for OpenSSL structs

### DIFF
--- a/src/bridge/memory_util/BUILD
+++ b/src/bridge/memory_util/BUILD
@@ -1,0 +1,35 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//src/bridge:__subpackages__"])
+
+cc_library(
+    name = "openssl_structs",
+    hdrs = ["openssl_structs.h"],
+    linkopts = ["-lcrypto"],
+)
+
+cc_test(
+    name = "openssl_structs_test",
+    size = "small",
+    srcs = ["openssl_structs_test.cc"],
+    deps = [
+        ":openssl_structs",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/bridge/memory_util/openssl_structs.h
+++ b/src/bridge/memory_util/openssl_structs.h
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+
+#include <openssl/engine.h>
+#include <openssl/rsa.h>
+
+namespace kmsengine {
+namespace bridge {
+namespace memory_util {
+
+// This file exposes smart pointer wrappers around various OpenSSL structs.
+// They should be used when all of the following conditions are met:
+//
+//    - The engine needs to instantiate a new OpenSSL struct.
+//    - The engine is responsible for owning the instance of that struct.
+//    - The engine is responsible for cleaning up the struct instance.
+//
+// Existing OpenSSL struct pointers passed from OpenSSL applications should not
+// be converted to smart pointers since the engine does not "own" that
+// pointer.
+
+// Smart pointer wrapper around OpenSSL's RSA struct. Just an alias for
+// convenience.
+using OpenSSLRsa = std::unique_ptr<RSA, decltype(&RSA_free)>;
+
+// Smart pointer wrapper around OpenSSL's RSA_METHOD struct. Just an alias for
+// convenience.
+using OpenSSLRsaMethod = std::unique_ptr<RSA_METHOD, decltype(&RSA_meth_free)>;
+
+// Constructs a `std::unique_ptr` object which owns a fresh RSA instance.
+// May return `nullptr` if no memory is available.
+//
+// The OpenSSL `RSA_free` function is automatically called to dispose
+// of the underlying RSA instance when the pointer goes out of scope.
+inline OpenSSLRsa MakeRsa() {
+  return OpenSSLRsa(RSA_new(), &RSA_free);
+}
+
+// Constructs a `std::unique_ptr` object which owns a fresh RSA_METHOD instance.
+// May return `nullptr` if no memory is available.
+//
+// The OpenSSL `RSA_meth_free` function is automatically called to dispose
+// of the underlying RSA_METHOD instance when the pointer goes out of scope.
+inline OpenSSLRsaMethod MakeRsaMethod(const char *name, int flags) {
+  return OpenSSLRsaMethod(RSA_meth_new(name, flags), &RSA_meth_free);
+}
+
+}  // namespace memory_util
+}  // namespace bridge
+}  // namespace kmsengine

--- a/src/bridge/memory_util/openssl_structs.h
+++ b/src/bridge/memory_util/openssl_structs.h
@@ -27,8 +27,18 @@ namespace memory_util {
 // They should be used when all of the following conditions are met:
 //
 //    - The engine needs to instantiate a new OpenSSL struct.
-//    - The engine is responsible for owning the instance of that struct.
-//    - The engine is responsible for cleaning up the struct instance.
+//
+//    - The engine (not OpenSSL, or another OpenSSL struct) "owns" the instance
+//      of that struct. (For example, while the engine is responsibile for
+//      instantiating both an `EVP_PKEY` and an `RSA` instance in the key
+//      loader, it should not use the smart pointer interface for the `RSA`
+//      instance since the `RSA` instance is "owned" by the `EVP_PKEY`. The
+//      `EVP_PKEY` should not be converted to a smart pointer as well since
+//      ownership of the `EVP_PKEY` is passed back to the client application.)
+//
+//    - The engine is responsible for cleaning up the struct instance (for,
+//      example, it doesn't pass ownership / cleanup responsibility of the
+//      instance to OpenSSL via an API function, etc.).
 //
 // Existing OpenSSL struct pointers passed from OpenSSL applications should not
 // be converted to smart pointers since the engine does not "own" that

--- a/src/bridge/memory_util/openssl_structs.h
+++ b/src/bridge/memory_util/openssl_structs.h
@@ -21,7 +21,6 @@
 
 namespace kmsengine {
 namespace bridge {
-namespace memory_util {
 
 // This file exposes smart pointer wrappers around various OpenSSL structs.
 // They should be used when all of the following conditions are met:
@@ -70,6 +69,5 @@ inline OpenSSLRsaMethod MakeRsaMethod(const char *name, int flags) {
   return OpenSSLRsaMethod(RSA_meth_new(name, flags), &RSA_meth_free);
 }
 
-}  // namespace memory_util
 }  // namespace bridge
 }  // namespace kmsengine

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <openssl/rsa.h>
 
@@ -24,35 +25,38 @@ namespace bridge {
 namespace memory_util {
 namespace {
 
+using ::testing::Not;
+using ::testing::IsNull;
+
 TEST(OpenSSLMakeTest, MakeRsaSetsDeleter) {
   auto rsa = MakeRsa();
-  EXPECT_NE(rsa.get(), nullptr);
+  ASSERT_THAT(rsa, Not(IsNull()));
   EXPECT_EQ(rsa.get_deleter(), &RSA_free);
 }
 
 TEST(OpenSSLMakeTest, MakeRsaMethodSetsDeleter) {
   auto rsa_method = MakeRsaMethod("", 0);
-  EXPECT_NE(rsa_method.get(), nullptr);
+  ASSERT_THAT(rsa_method, Not(IsNull()));
   EXPECT_EQ(rsa_method.get_deleter(), &RSA_meth_free);
 }
 
 TEST(OpenSSLMakeTest, MakeRsaMethodSetsName) {
   auto empty_name = MakeRsaMethod("", 0);
-  ASSERT_NE(empty_name.get(), nullptr);
+  ASSERT_THAT(empty_name, Not(IsNull()));
   EXPECT_STREQ(RSA_meth_get0_name(empty_name.get()), "");
 
   auto some_name = MakeRsaMethod("my-name", 0);
-  ASSERT_NE(some_name.get(), nullptr);
+  ASSERT_THAT(some_name, Not(IsNull()));
   EXPECT_STREQ(RSA_meth_get0_name(some_name.get()), "my-name");
 }
 
 TEST(OpenSSLMakeTest, MakeRsaMethodSetsFlags) {
   auto with_flag = MakeRsaMethod("", RSA_FLAG_EXT_PKEY);
-  ASSERT_NE(with_flag.get(), nullptr);
+  ASSERT_THAT(with_flag, Not(IsNull()));
   EXPECT_TRUE(RSA_meth_get_flags(with_flag.get()) & RSA_FLAG_EXT_PKEY);
 
   auto without_flag = MakeRsaMethod("", 0);
-  ASSERT_NE(without_flag.get(), nullptr);
+  ASSERT_THAT(without_flag, Not(IsNull()));
   EXPECT_FALSE(RSA_meth_get_flags(without_flag.get()) & RSA_FLAG_EXT_PKEY);
 }
 

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <openssl/rsa.h>
+
+#include "src/bridge/memory_util/openssl_structs.h"
+
+namespace kmsengine {
+namespace bridge {
+namespace memory_util {
+namespace {
+
+TEST(OpenSSLMakeTest, MakeRsaSetsDeleter) {
+  auto rsa = MakeRsa();
+  EXPECT_NE(rsa.get(), nullptr);
+  EXPECT_EQ(rsa.get_deleter(), &RSA_free);
+}
+
+TEST(OpenSSLMakeTest, MakeRsaMethodSetsDeleter) {
+  auto rsa_method = MakeRsaMethod("", 0);
+  EXPECT_NE(rsa_method.get(), nullptr);
+  EXPECT_EQ(rsa_method.get_deleter(), &RSA_meth_free);
+}
+
+TEST(OpenSSLMakeTest, MakeRsaMethodSetsName) {
+  auto empty_name = MakeRsaMethod("", 0);
+  ASSERT_NE(empty_name.get(), nullptr);
+  EXPECT_STREQ(RSA_meth_get0_name(empty_name.get()), "");
+
+  auto some_name = MakeRsaMethod("my-name", 0);
+  ASSERT_NE(some_name.get(), nullptr);
+  EXPECT_STREQ(RSA_meth_get0_name(some_name.get()), "my-name");
+}
+
+TEST(OpenSSLMakeTest, MakeRsaMethodSetsFlags) {
+  auto with_flag = MakeRsaMethod("", RSA_FLAG_EXT_PKEY);
+  ASSERT_NE(with_flag.get(), nullptr);
+  EXPECT_TRUE(RSA_meth_get_flags(with_flag.get()) & RSA_FLAG_EXT_PKEY);
+
+  auto without_flag = MakeRsaMethod("", 0);
+  ASSERT_NE(without_flag.get(), nullptr);
+  EXPECT_FALSE(RSA_meth_get_flags(without_flag.get()) & RSA_FLAG_EXT_PKEY);
+}
+
+}  // namespace
+}  // namespace memory_util
+}  // namespace bridge
+}  // namespace kmsengine

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -22,7 +22,6 @@
 
 namespace kmsengine {
 namespace bridge {
-namespace memory_util {
 namespace {
 
 using ::testing::Not;
@@ -61,6 +60,5 @@ TEST(OpenSSLMakeTest, MakeRsaMethodSetsFlags) {
 }
 
 }  // namespace
-}  // namespace memory_util
 }  // namespace bridge
 }  // namespace kmsengine


### PR DESCRIPTION
Part of #14.

Adds a `memory_util` framework for making smart pointers for OpenSSL structs to the bridge layer. This follows [this pattern from googleapis/google-cloud-cpp](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/storage/internal/openssl_util.cc#L43-L46).

Not sure how to explicitly test that the deleter is called when the pointer goes out of scope, but assuming that `std::unique_ptr` is implemented correctly, I would say that we just need to check that the deleter is set.