### PR TITLE
Add Client interface

### DIFF
--- a/src/backing/client/BUILD
+++ b/src/backing/client/BUILD
@@ -1,0 +1,27 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//src:__subpackages__"])
+
+cc_library(
+    name = "client",
+    hdrs = ["client.h"],
+    deps = [
+        "//src/backing/status",
+    ],
+)

--- a/src/backing/client/BUILD
+++ b/src/backing/client/BUILD
@@ -23,5 +23,8 @@ cc_library(
     hdrs = ["client.h"],
     deps = [
         "//src/backing/status",
+        "@com_google_googleapis//:googleapis_system_includes",
+        "@com_google_googleapis//google/cloud/kms/v1:kms_cc_grpc",
+        "@com_google_googleapis//google/cloud/kms/v1:kms_cc_proto",
     ],
 )

--- a/src/backing/client/client.h
+++ b/src/backing/client/client.h
@@ -19,6 +19,9 @@
 
 #include <string>
 
+#include <google/cloud/kms/v1/service.grpc.pb.h>
+#include <google/cloud/kms/v1/service.pb.h>
+
 #include "src/backing/status/status.h"
 
 namespace kmsengine {

--- a/src/backing/client/client.h
+++ b/src/backing/client/client.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BACKING_CLIENT_CLIENT_H_
+#define KMSENGINE_BACKING_CLIENT_CLIENT_H_
+
+#include <string>
+
+#include "src/backing/status/status.h"
+
+namespace kmsengine {
+namespace backing {
+
+// Enum denoting the hash algorithm used to produce a particular digest.
+//
+// Defined as an alias since the bridge layer needs to have access to the
+// protobuf-generated `DigestCase` definition without directly importing
+// gRPC dependencies.
+using DigestCase = google::cloud::kms::v1::Digest::DigestCase;
+
+// Defines the interface used to communicate with the Google Cloud KMS API.
+class Client {
+ public:
+  virtual ~Client() = default;
+
+  // Signs data using the CryptoKeyVersion `key_version_resource_id`. Produces
+  // a signature that can be verified with the public key retrieved from
+  // `GetPublicKey`.
+  virtual StatusOr<std::string> AsymmetricSign(
+      std::string key_version_resource_id, DigestCase digest_case,
+      std::string digest_bytes) = 0;
+};
+
+}  // namespace backing
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BACKING_CLIENT_CLIENT_H_

--- a/src/testing_util/BUILD
+++ b/src/testing_util/BUILD
@@ -1,0 +1,29 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//src:__subpackages__"])
+
+cc_library(
+    name = "mock_client",
+    hdrs = ["mock_client.h"],
+    deps = [
+        "//src/backing/client",
+        "//src/backing/status",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/testing_util/mock_client.h
+++ b/src/testing_util/mock_client.h
@@ -27,9 +27,7 @@
 #include "src/backing/status/status.h"
 
 namespace kmsengine {
-namespace bridge {
-namespace rsa {
-namespace testing_util {
+namespace backing {
 
 class MockClient : public Client {
  public:
@@ -39,9 +37,7 @@ class MockClient : public Client {
               (override));
 };
 
-}  // namespace testing_util
-}  // namespace rsa
-}  // namespace bridge
+}  // namespace backing
 }  // namespace kmsengine
 
 #endif  // KMSENGINE_BRIDGE_RSA_TESTING_UTIL_MOCK_RSA_KEY_H_

--- a/src/testing_util/mock_client.h
+++ b/src/testing_util/mock_client.h
@@ -1,0 +1,47 @@
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BRIDGE_RSA_TESTING_UTIL_MOCK_RSA_KEY_H_
+#define KMSENGINE_BRIDGE_RSA_TESTING_UTIL_MOCK_RSA_KEY_H_
+
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "src/backing/client/client.h"
+#include "src/backing/status/status.h"
+
+namespace kmsengine {
+namespace bridge {
+namespace rsa {
+namespace testing_util {
+
+class MockClient : public Client {
+ public:
+  MOCK_METHOD(StatusOr<std::string>, AsymmetricSign,
+              (std::string key_version_resource_id, DigestCase digest_case,
+               std::string digest_bytes),
+              (override));
+};
+
+}  // namespace testing_util
+}  // namespace rsa
+}  // namespace bridge
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BRIDGE_RSA_TESTING_UTIL_MOCK_RSA_KEY_H_


### PR DESCRIPTION
Part of #11.

Defines `Client` interface based on discussion regarding shift from native request definitions to using the protobuf definitions. Separate PR from actual implementation since this interface is blocking other components. (Are tests necessary here even if it's just an interface?)

Also adds a `MockClient` for testing.