### PR TITLE
Increase Cloud Build timeout to 16.7 minutes.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,3 +1,4 @@
 steps:
 - name: 'ubuntu'
   args: ['bash', 'bazel_build.sh']
+timeout: 1000s


### PR DESCRIPTION
Cloud Build is currently taking over 10 minutes, likely as the result of adding the gRPC build.