### PR TITLE
Add more OpenSSL structs to memory_util

### DIFF
--- a/src/bridge/memory_util/openssl_structs.h
+++ b/src/bridge/memory_util/openssl_structs.h
@@ -46,21 +46,46 @@ namespace bridge {
 // be converted to smart pointers since the engine does not "own" that
 // pointer.
 
+// Smart pointer wrapper around OpenSSL's ENGINE struct. Just an alias for
+// convenience.
+using OpenSslEngine = std::unique_ptr<ENGINE, decltype(&ENGINE_free)>;
+
+// Smart pointer wrapper around OpenSSL's EVP_PKEY struct. Just an alias for
+// convenience.
+using OpenSslEvpPkey = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+
 // Smart pointer wrapper around OpenSSL's RSA struct. Just an alias for
 // convenience.
-using OpenSSLRsa = std::unique_ptr<RSA, decltype(&RSA_free)>;
+using OpenSslRsa = std::unique_ptr<RSA, decltype(&RSA_free)>;
 
 // Smart pointer wrapper around OpenSSL's RSA_METHOD struct. Just an alias for
 // convenience.
-using OpenSSLRsaMethod = std::unique_ptr<RSA_METHOD, decltype(&RSA_meth_free)>;
+using OpenSslRsaMethod = std::unique_ptr<RSA_METHOD, decltype(&RSA_meth_free)>;
+
+// Constructs a `std::unique_ptr` object which owns a fresh RSA_METHOD instance.
+// May return `nullptr` if no memory is available.
+//
+// The OpenSSL `RSA_meth_free` function is automatically called to dispose
+// of the underlying RSA_METHOD instance when the pointer goes out of scope.
+inline OpenSslEngine MakeEngine() {
+  return OpenSslEngine(ENGINE_new(), &ENGINE_free);
+}
+// Constructs a `std::unique_ptr` object which owns a fresh EVP_PKEY instance.
+// May return `nullptr` if no memory is available.
+//
+// The OpenSSL `EVP_PKEY_free` function is automatically called to dispose
+// of the underlying EVP_PKEY instance when the pointer goes out of scope.
+inline OpenSslEvpPkey MakeEvpPkey() {
+  return OpenSslEvpPkey(EVP_PKEY_new(), &EVP_PKEY_free);
+}
 
 // Constructs a `std::unique_ptr` object which owns a fresh RSA instance.
 // May return `nullptr` if no memory is available.
 //
 // The OpenSSL `RSA_free` function is automatically called to dispose
 // of the underlying RSA instance when the pointer goes out of scope.
-inline OpenSSLRsa MakeRsa() {
-  return OpenSSLRsa(RSA_new(), &RSA_free);
+inline OpenSslRsa MakeRsa() {
+  return OpenSslRsa(RSA_new(), &RSA_free);
 }
 
 // Constructs a `std::unique_ptr` object which owns a fresh RSA_METHOD instance.
@@ -68,8 +93,8 @@ inline OpenSSLRsa MakeRsa() {
 //
 // The OpenSSL `RSA_meth_free` function is automatically called to dispose
 // of the underlying RSA_METHOD instance when the pointer goes out of scope.
-inline OpenSSLRsaMethod MakeRsaMethod(const char *name, int flags) {
-  return OpenSSLRsaMethod(RSA_meth_new(name, flags), &RSA_meth_free);
+inline OpenSslRsaMethod MakeRsaMethod(const char *name, int flags) {
+  return OpenSslRsaMethod(RSA_meth_new(name, flags), &RSA_meth_free);
 }
 
 }  // namespace bridge

--- a/src/bridge/memory_util/openssl_structs.h
+++ b/src/bridge/memory_util/openssl_structs.h
@@ -62,14 +62,15 @@ using OpenSslRsa = std::unique_ptr<RSA, decltype(&RSA_free)>;
 // convenience.
 using OpenSslRsaMethod = std::unique_ptr<RSA_METHOD, decltype(&RSA_meth_free)>;
 
-// Constructs a `std::unique_ptr` object which owns a fresh RSA_METHOD instance.
+// Constructs a `std::unique_ptr` object which owns a fresh ENGINE instance.
 // May return `nullptr` if no memory is available.
 //
-// The OpenSSL `RSA_meth_free` function is automatically called to dispose
-// of the underlying RSA_METHOD instance when the pointer goes out of scope.
+// The OpenSSL `ENGINE_free` function is automatically called to dispose
+// of the underlying ENGINE instance when the pointer goes out of scope.
 inline OpenSslEngine MakeEngine() {
   return OpenSslEngine(ENGINE_new(), &ENGINE_free);
 }
+
 // Constructs a `std::unique_ptr` object which owns a fresh EVP_PKEY instance.
 // May return `nullptr` if no memory is available.
 //

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -27,13 +27,13 @@ namespace {
 using ::testing::Not;
 using ::testing::IsNull;
 
-TEST(OpenSSLMakeTest, MakeEngineSetsDeleter) {
+TEST(OpenSslMakeTest, MakeEngineSetsDeleter) {
   auto engine = MakeEngine();
   ASSERT_THAT(engine, Not(IsNull()));
   EXPECT_EQ(engine.get_deleter(), &ENGINE_free);
 }
 
-TEST(OpenSSLMakeTest, MakeEvpPkeySetsDeleter) {
+TEST(OpenSslMakeTest, MakeEvpPkeySetsDeleter) {
   auto evp_pkey = MakeEvpPkey();
   ASSERT_THAT(evp_pkey, Not(IsNull()));
   EXPECT_EQ(evp_pkey.get_deleter(), &EVP_PKEY_free);

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -27,19 +27,25 @@ namespace {
 using ::testing::Not;
 using ::testing::IsNull;
 
-TEST(OpenSSLMakeTest, MakeRsaSetsDeleter) {
+TEST(OpenSSLMakeTest, MakeEngineSetsDeleter) {
+  auto engine = MakeEngine();
+  ASSERT_THAT(engine, Not(IsNull()));
+  EXPECT_EQ(engine.get_deleter(), &ENGINE_free);
+}
+
+TEST(OpenSslStructsTest, MakeRsaSetsDeleter) {
   auto rsa = MakeRsa();
   ASSERT_THAT(rsa, Not(IsNull()));
   EXPECT_EQ(rsa.get_deleter(), &RSA_free);
 }
 
-TEST(OpenSSLMakeTest, MakeRsaMethodSetsDeleter) {
+TEST(OpenSslStructsTest, MakeRsaMethodSetsDeleter) {
   auto rsa_method = MakeRsaMethod("", 0);
   ASSERT_THAT(rsa_method, Not(IsNull()));
   EXPECT_EQ(rsa_method.get_deleter(), &RSA_meth_free);
 }
 
-TEST(OpenSSLMakeTest, MakeRsaMethodSetsName) {
+TEST(OpenSslStructsTest, MakeRsaMethodSetsName) {
   auto empty_name = MakeRsaMethod("", 0);
   ASSERT_THAT(empty_name, Not(IsNull()));
   EXPECT_STREQ(RSA_meth_get0_name(empty_name.get()), "");
@@ -49,7 +55,7 @@ TEST(OpenSSLMakeTest, MakeRsaMethodSetsName) {
   EXPECT_STREQ(RSA_meth_get0_name(some_name.get()), "my-name");
 }
 
-TEST(OpenSSLMakeTest, MakeRsaMethodSetsFlags) {
+TEST(OpenSslStructsTest, MakeRsaMethodSetsFlags) {
   auto with_flag = MakeRsaMethod("", RSA_FLAG_EXT_PKEY);
   ASSERT_THAT(with_flag, Not(IsNull()));
   EXPECT_TRUE(RSA_meth_get_flags(with_flag.get()) & RSA_FLAG_EXT_PKEY);

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -34,9 +34,9 @@ TEST(OpenSSLMakeTest, MakeEngineSetsDeleter) {
 }
 
 TEST(OpenSSLMakeTest, MakeEvpPkeySetsDeleter) {
-  auto engine = MakeEvpPkey();
-  ASSERT_THAT(engine, Not(IsNull()));
-  EXPECT_EQ(engine.get_deleter(), &ENGINE_free);
+  auto evp_pkey = MakeEvpPkey();
+  ASSERT_THAT(evp_pkey, Not(IsNull()));
+  EXPECT_EQ(evp_pkey.get_deleter(), &EVP_PKEY_free);
 }
 
 TEST(OpenSslStructsTest, MakeRsaSetsDeleter) {

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -33,6 +33,12 @@ TEST(OpenSSLMakeTest, MakeEngineSetsDeleter) {
   EXPECT_EQ(engine.get_deleter(), &ENGINE_free);
 }
 
+TEST(OpenSSLMakeTest, MakeEvpPkeySetsDeleter) {
+  auto engine = MakeEvpPkey();
+  ASSERT_THAT(engine, Not(IsNull()));
+  EXPECT_EQ(engine.get_deleter(), &ENGINE_free);
+}
+
 TEST(OpenSslStructsTest, MakeRsaSetsDeleter) {
   auto rsa = MakeRsa();
   ASSERT_THAT(rsa, Not(IsNull()));


### PR DESCRIPTION
Part of #45 and #12. Resolves #50.

Adds a few more OpenSSL structs to `memory_util`.