### PR TITLE
Fix null-termination errors in MakeDigest

### DIFF
--- a/src/backing/client/grpc_client/BUILD
+++ b/src/backing/client/grpc_client/BUILD
@@ -62,7 +62,6 @@ cc_library(
         "//src/backing/client:digest_case",
         "//src/backing/status",
         "@com_github_grpc_grpc//:grpc++",
-        "@com_google_absl//absl/strings",
         "@com_google_googleapis//google/cloud/kms/v1:kms_cc_proto",
     ],
 )

--- a/src/backing/client/grpc_client/proto_util.cc
+++ b/src/backing/client/grpc_client/proto_util.cc
@@ -19,7 +19,6 @@
 #include <memory>
 #include <string>
 
-#include "absl/strings/string_view.h"
 #include "google/cloud/kms/v1/resources.pb.h"
 #include "google/cloud/kms/v1/service.pb.h"
 #include "grpcpp/grpcpp.h"
@@ -74,17 +73,17 @@ StatusCode MapStatusCode(grpc::StatusCode const& code) {
 }  // namespace
 
 google::cloud::kms::v1::Digest MakeDigest(DigestCase type,
-                                          absl::string_view digest_bytes) {
+                                          std::string digest_bytes) {
   google::cloud::kms::v1::Digest proto_digest;
   switch (type) {
     case DigestCase::kSha256:
-      proto_digest.set_sha256(digest_bytes.data());
+      proto_digest.set_sha256(digest_bytes.data(), digest_bytes.length());
       break;
     case DigestCase::kSha384:
-      proto_digest.set_sha384(digest_bytes.data());
+      proto_digest.set_sha384(digest_bytes.data(), digest_bytes.length());
       break;
     case DigestCase::kSha512:
-      proto_digest.set_sha512(digest_bytes.data());
+      proto_digest.set_sha512(digest_bytes.data(), digest_bytes.length());
       break;
   }
   return proto_digest;

--- a/src/backing/client/grpc_client/proto_util.cc
+++ b/src/backing/client/grpc_client/proto_util.cc
@@ -77,13 +77,13 @@ google::cloud::kms::v1::Digest MakeDigest(DigestCase type,
   google::cloud::kms::v1::Digest proto_digest;
   switch (type) {
     case DigestCase::kSha256:
-      proto_digest.set_sha256(digest_bytes.data(), digest_bytes.length());
+      proto_digest.set_sha256(digest_bytes);
       break;
     case DigestCase::kSha384:
-      proto_digest.set_sha384(digest_bytes.data(), digest_bytes.length());
+      proto_digest.set_sha384(digest_bytes);
       break;
     case DigestCase::kSha512:
-      proto_digest.set_sha512(digest_bytes.data(), digest_bytes.length());
+      proto_digest.set_sha512(digest_bytes);
       break;
   }
   return proto_digest;

--- a/src/backing/client/grpc_client/proto_util.h
+++ b/src/backing/client/grpc_client/proto_util.h
@@ -19,7 +19,6 @@
 
 #include <string>
 
-#include "absl/strings/string_view.h"
 #include "google/cloud/kms/v1/resources.pb.h"
 #include "google/cloud/kms/v1/service.pb.h"
 #include "grpcpp/grpcpp.h"
@@ -32,7 +31,7 @@ namespace backing {
 
 // Factory function which creates an protobuf `Digest`.
 google::cloud::kms::v1::Digest MakeDigest(DigestCase type,
-                                          absl::string_view digest_bytes);
+                                          std::string digest_bytes);
 
 // Helper function for converting a `grpc::Status` to a engine-native `Status`.
 Status FromGrpcStatusToStatus(grpc::Status const& status);

--- a/src/backing/client/grpc_client/proto_util_test.cc
+++ b/src/backing/client/grpc_client/proto_util_test.cc
@@ -20,6 +20,7 @@
 #include <gmock/gmock.h>
 
 #include "absl/strings/str_cat.h"
+#include "absl/strings/escaping.h"
 #include "google/cloud/kms/v1/resources.pb.h"
 #include "google/cloud/kms/v1/service.pb.h"
 #include "src/backing/client/digest_case.h"
@@ -52,8 +53,23 @@ std::string GetDigestBytes(google::cloud::kms::v1::Digest digest) {
 // Sample digests for testing purposes.
 const std::string kSampleDigests[] = {
   // Example SHA-256 digest of "hello world" for testing.
-  "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+  absl::HexStringToBytes(
+      "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"),
+  // Check that signing operations handle digests containing null bytes.
+  absl::HexStringToBytes(
+      "ababab0000000000000000000000000000000000000000000000000000bababa"),
+  // Ends with null bytes.
+  absl::HexStringToBytes(
+      "bababa0000000000000000000000000000000000000000000000000000000000"),
+  // Starts with null bytes and ends with non-null bytes.
+  absl::HexStringToBytes(
+      "0000000000000000000000000000000000000000000000000000000000ababab"),
+  // Check all null string.
+  absl::HexStringToBytes(
+      "0000000000000000000000000000000000000000000000000000000000000000"),
+  // Check arbitrary string.
   "an arbitrary digest",
+  // Check empty string.
   "",
 };
 


### PR DESCRIPTION
Resolves #88.

For simplicity, I converted the `string_view` back to a `std::string`—can always add it back if needed.