### PR TITLE
Increase Google Cloud Build timeout to 30 minutes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
 steps:
 - name: 'ubuntu'
   args: ['bash', 'bazel_build.sh']
-timeout: 1000s
+timeout: 1800s


### PR DESCRIPTION
Resolves #94.