### PR TITLE
Add more OpenSSL structs to memory_util

### DIFF
--- a/src/bridge/memory_util/openssl_structs.h
+++ b/src/bridge/memory_util/openssl_structs.h
@@ -87,8 +87,11 @@ inline OpenSslEcKey MakeEcKey() {
   return OpenSslEcKey(EC_KEY_new(), &EC_KEY_free);
 }
 
-// Constructs a `std::unique_ptr` object which owns a fresh EC_KEY_METHOD
-// instance. May return `nullptr` if no memory is available.
+// Constructs a `std::unique_ptr` object which contains a `EC_KEY_METHOD`
+// instance that is a shallow copy of the input `method`. May return `nullptr`
+// if no memory is available.
+//
+// If `method` == nullptr, then returns a fresh `EC_KEY_METHOD` instance.
 //
 // The OpenSSL `EC_KEY_METHOD_free` function is automatically called to dispose
 // of the underlying EC_KEY_METHOD instance when the pointer goes out of scope.
@@ -96,11 +99,7 @@ inline OpenSslEcKeyMethod MakeEcKeyMethod(const EC_KEY_METHOD *method) {
   return OpenSslEcKeyMethod(EC_KEY_METHOD_new(method), &EC_KEY_METHOD_free);
 }
 
-// Constructs a `std::unique_ptr` object which owns a fresh EC_KEY_METHOD
-// instance. May return `nullptr` if no memory is available.
-//
-// The OpenSSL `EC_KEY_METHOD_free` function is automatically called to dispose
-// of the underlying EC_KEY_METHOD instance when the pointer goes out of scope.
+// Alias for `MakeEcKeyMethod(nullptr)`.
 inline OpenSslEcKeyMethod MakeEcKeyMethod() {
   return MakeEcKeyMethod(nullptr);
 }

--- a/src/bridge/memory_util/openssl_structs.h
+++ b/src/bridge/memory_util/openssl_structs.h
@@ -19,7 +19,9 @@
 
 #include <memory>
 
+#include <openssl/ec.h>
 #include <openssl/engine.h>
+#include <openssl/evp.h>
 #include <openssl/rsa.h>
 
 namespace kmsengine {
@@ -46,6 +48,15 @@ namespace bridge {
 // be converted to smart pointers since the engine does not "own" that
 // pointer.
 
+// Smart pointer wrapper around OpenSSL's EC_KEY struct. Just an alias for
+// convenience.
+using OpenSslEcKey = std::unique_ptr<EC_KEY, decltype(&EC_KEY_free)>;
+
+// Smart pointer wrapper around OpenSSL's EC_KEY_METHOD struct. Just an alias
+// for convenience.
+using OpenSslEcKeyMethod = std::unique_ptr<EC_KEY_METHOD,
+                                           decltype(&EC_KEY_METHOD_free)>;
+
 // Smart pointer wrapper around OpenSSL's ENGINE struct. Just an alias for
 // convenience.
 using OpenSslEngine = std::unique_ptr<ENGINE, decltype(&ENGINE_free)>;
@@ -54,6 +65,11 @@ using OpenSslEngine = std::unique_ptr<ENGINE, decltype(&ENGINE_free)>;
 // convenience.
 using OpenSslEvpPkey = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
 
+// Smart pointer wrapper around OpenSSL's EVP_MD_CTX struct. Just an alias for
+// convenience.
+using OpenSslEvpDigestContext = std::unique_ptr<EVP_MD_CTX,
+                                              decltype(&EVP_MD_CTX_free)>;
+
 // Smart pointer wrapper around OpenSSL's RSA struct. Just an alias for
 // convenience.
 using OpenSslRsa = std::unique_ptr<RSA, decltype(&RSA_free)>;
@@ -61,6 +77,33 @@ using OpenSslRsa = std::unique_ptr<RSA, decltype(&RSA_free)>;
 // Smart pointer wrapper around OpenSSL's RSA_METHOD struct. Just an alias for
 // convenience.
 using OpenSslRsaMethod = std::unique_ptr<RSA_METHOD, decltype(&RSA_meth_free)>;
+
+// Constructs a `std::unique_ptr` object which owns a fresh ENGINE instance.
+// May return `nullptr` if no memory is available.
+//
+// The OpenSSL `ENGINE_free` function is automatically called to dispose
+// of the underlying ENGINE instance when the pointer goes out of scope.
+inline OpenSslEcKey MakeEcKey() {
+  return OpenSslEcKey(EC_KEY_new(), &EC_KEY_free);
+}
+
+// Constructs a `std::unique_ptr` object which owns a fresh EC_KEY_METHOD
+// instance. May return `nullptr` if no memory is available.
+//
+// The OpenSSL `EC_KEY_METHOD_free` function is automatically called to dispose
+// of the underlying EC_KEY_METHOD instance when the pointer goes out of scope.
+inline OpenSslEcKeyMethod MakeEcKeyMethod(const EC_KEY_METHOD *method) {
+  return OpenSslEcKeyMethod(EC_KEY_METHOD_new(method), &EC_KEY_METHOD_free);
+}
+
+// Constructs a `std::unique_ptr` object which owns a fresh EC_KEY_METHOD
+// instance. May return `nullptr` if no memory is available.
+//
+// The OpenSSL `EC_KEY_METHOD_free` function is automatically called to dispose
+// of the underlying EC_KEY_METHOD instance when the pointer goes out of scope.
+inline OpenSslEcKeyMethod MakeEcKeyMethod() {
+  return MakeEcKeyMethod(nullptr);
+}
 
 // Constructs a `std::unique_ptr` object which owns a fresh ENGINE instance.
 // May return `nullptr` if no memory is available.
@@ -78,6 +121,15 @@ inline OpenSslEngine MakeEngine() {
 // of the underlying EVP_PKEY instance when the pointer goes out of scope.
 inline OpenSslEvpPkey MakeEvpPkey() {
   return OpenSslEvpPkey(EVP_PKEY_new(), &EVP_PKEY_free);
+}
+
+// Constructs a `std::unique_ptr` object which owns a fresh EVP_MD_CTX
+// instance. May return `nullptr` if no memory is available.
+//
+// The OpenSSL `EVP_MD_CTX_free` function is automatically called to dispose
+// of the underlying EVP_MD_CTX instance when the pointer goes out of scope.
+inline OpenSslEvpDigestContext MakeEvpDigestContext() {
+  return OpenSslEvpDigestContext(EVP_MD_CTX_new(), &EVP_MD_CTX_free);
 }
 
 // Constructs a `std::unique_ptr` object which owns a fresh RSA instance.

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -16,6 +16,9 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <openssl/ec.h>
+#include <openssl/engine.h>
+#include <openssl/evp.h>
 #include <openssl/rsa.h>
 
 #include "src/bridge/memory_util/openssl_structs.h"
@@ -24,50 +27,67 @@ namespace kmsengine {
 namespace bridge {
 namespace {
 
-using ::testing::Not;
-using ::testing::IsNull;
+using ::testing::NotNull;
+
+TEST(OpenSslMakeTest, MakeEcKeySetsDeleter) {
+  auto ec_key = MakeEcKey();
+  ASSERT_THAT(ec_key, NotNull());
+  EXPECT_EQ(ec_key.get_deleter(), &EC_KEY_free);
+}
+
+TEST(OpenSslMakeTest, MakeEcKeyMethodSetsDeleter) {
+  auto ec_key_method = MakeEcKeyMethod();
+  ASSERT_THAT(ec_key_method, NotNull());
+  EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
+}
 
 TEST(OpenSslMakeTest, MakeEngineSetsDeleter) {
   auto engine = MakeEngine();
-  ASSERT_THAT(engine, Not(IsNull()));
+  ASSERT_THAT(engine, NotNull());
   EXPECT_EQ(engine.get_deleter(), &ENGINE_free);
 }
 
 TEST(OpenSslMakeTest, MakeEvpPkeySetsDeleter) {
   auto evp_pkey = MakeEvpPkey();
-  ASSERT_THAT(evp_pkey, Not(IsNull()));
+  ASSERT_THAT(evp_pkey, NotNull());
   EXPECT_EQ(evp_pkey.get_deleter(), &EVP_PKEY_free);
+}
+
+TEST(OpenSslMakeTest, MakeEvpDigestContextSetsDeleter) {
+  auto context = MakeEvpDigestContext();
+  ASSERT_THAT(context, NotNull());
+  EXPECT_EQ(context.get_deleter(), &EVP_MD_CTX_free);
 }
 
 TEST(OpenSslStructsTest, MakeRsaSetsDeleter) {
   auto rsa = MakeRsa();
-  ASSERT_THAT(rsa, Not(IsNull()));
+  ASSERT_THAT(rsa, NotNull());
   EXPECT_EQ(rsa.get_deleter(), &RSA_free);
 }
 
 TEST(OpenSslStructsTest, MakeRsaMethodSetsDeleter) {
   auto rsa_method = MakeRsaMethod("", 0);
-  ASSERT_THAT(rsa_method, Not(IsNull()));
+  ASSERT_THAT(rsa_method, NotNull());
   EXPECT_EQ(rsa_method.get_deleter(), &RSA_meth_free);
 }
 
 TEST(OpenSslStructsTest, MakeRsaMethodSetsName) {
   auto empty_name = MakeRsaMethod("", 0);
-  ASSERT_THAT(empty_name, Not(IsNull()));
+  ASSERT_THAT(empty_name, NotNull());
   EXPECT_STREQ(RSA_meth_get0_name(empty_name.get()), "");
 
   auto some_name = MakeRsaMethod("my-name", 0);
-  ASSERT_THAT(some_name, Not(IsNull()));
+  ASSERT_THAT(some_name, NotNull());
   EXPECT_STREQ(RSA_meth_get0_name(some_name.get()), "my-name");
 }
 
 TEST(OpenSslStructsTest, MakeRsaMethodSetsFlags) {
   auto with_flag = MakeRsaMethod("", RSA_FLAG_EXT_PKEY);
-  ASSERT_THAT(with_flag, Not(IsNull()));
+  ASSERT_THAT(with_flag, NotNull());
   EXPECT_TRUE(RSA_meth_get_flags(with_flag.get()) & RSA_FLAG_EXT_PKEY);
 
   auto without_flag = MakeRsaMethod("", 0);
-  ASSERT_THAT(without_flag, Not(IsNull()));
+  ASSERT_THAT(without_flag, NotNull());
   EXPECT_FALSE(RSA_meth_get_flags(without_flag.get()) & RSA_FLAG_EXT_PKEY);
 }
 

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -48,14 +48,13 @@ TEST(OpenSslMakeTest, MakeEcKeyMethodPerformsShallowCopy) {
   ASSERT_THAT(ec_key_method, NotNull());
   EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
 
-  EXPECT_EQ(EC_KEY_METHOD_get_init(ec_key_method.get()),
-            EC_KEY_METHOD_get_init(default_ec_key_method));
-  EXPECT_EQ(EC_KEY_METHOD_get_compute_key(ec_key_method.get()),
-            EC_KEY_METHOD_get_compute_key(default_ec_key_method));
-  EXPECT_EQ(EC_KEY_METHOD_get_sign(ec_key_method.get()),
-            EC_KEY_METHOD_get_sign(default_ec_key_method));
-  EXPECT_EQ(EC_KEY_METHOD_get_verify(ec_key_method.get()),
-            EC_KEY_METHOD_get_verify(default_ec_key_method));
+  auto actual_init;
+  EC_KEY_METHOD_get_init(ec_key_method.get(), &actual_init);
+
+  auto expected_init;
+  EC_KEY_METHOD_get_init(default_ec_key_method, &expected_init);
+
+  EXPECT_EQ(actual_init, expected_init);
 }
 
 TEST(OpenSslMakeTest, MakeEngineSetsDeleter) {

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -48,13 +48,13 @@ TEST(OpenSslMakeTest, MakeEcKeyMethodPerformsShallowCopy) {
   ASSERT_THAT(ec_key_method, NotNull());
   EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
 
-  auto actual_init;
-  EC_KEY_METHOD_get_init(ec_key_method.get(), &actual_init);
+  int (*pkeygen)(EC_KEY *key) actual_keygen_function;
+  EC_KEY_METHOD_get_keygen(ec_key_method.get(), &actual_keygen_function);
 
-  auto expected_init;
-  EC_KEY_METHOD_get_init(default_ec_key_method, &expected_init);
+  int (*pkeygen)(EC_KEY *key) expected_keygen_function;
+  EC_KEY_METHOD_get_keygen(default_ec_key_method, &expected_keygen_function);
 
-  EXPECT_EQ(actual_init, expected_init);
+  EXPECT_EQ(actual_keygen_function, expected_keygen_function);
 }
 
 TEST(OpenSslMakeTest, MakeEngineSetsDeleter) {

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -30,13 +30,13 @@ namespace {
 using ::testing::NotNull;
 
 TEST(OpenSslMakeTest, MakeEcKeySetsDeleter) {
-  auto ec_key = MakeEcKey();
+  OpenSslEcKey ec_key = MakeEcKey();
   ASSERT_THAT(ec_key, NotNull());
   EXPECT_EQ(ec_key.get_deleter(), &EC_KEY_free);
 }
 
 TEST(OpenSslMakeTest, MakeEcKeyMethodSetsDeleter) {
-  auto ec_key_method = MakeEcKeyMethod();
+  OpenSslEcKeyMethod ec_key_method = MakeEcKeyMethod();
   ASSERT_THAT(ec_key_method, NotNull());
   EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
 }
@@ -44,7 +44,7 @@ TEST(OpenSslMakeTest, MakeEcKeyMethodSetsDeleter) {
 TEST(OpenSslMakeTest, MakeEcKeyMethodPerformsShallowCopy) {
   const EC_KEY_METHOD *default_ec_key_method = EC_KEY_OpenSSL();
 
-  auto ec_key_method = MakeEcKeyMethod(default_ec_key_method);
+  OpenSslEcKeyMethod ec_key_method = MakeEcKeyMethod(default_ec_key_method);
   ASSERT_THAT(ec_key_method, NotNull());
   EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
 
@@ -58,51 +58,51 @@ TEST(OpenSslMakeTest, MakeEcKeyMethodPerformsShallowCopy) {
 }
 
 TEST(OpenSslMakeTest, MakeEngineSetsDeleter) {
-  auto engine = MakeEngine();
+  OpenSslEngine engine = MakeEngine();
   ASSERT_THAT(engine, NotNull());
   EXPECT_EQ(engine.get_deleter(), &ENGINE_free);
 }
 
 TEST(OpenSslMakeTest, MakeEvpPkeySetsDeleter) {
-  auto evp_pkey = MakeEvpPkey();
+  OpenSslEvpPkey evp_pkey = MakeEvpPkey();
   ASSERT_THAT(evp_pkey, NotNull());
   EXPECT_EQ(evp_pkey.get_deleter(), &EVP_PKEY_free);
 }
 
 TEST(OpenSslMakeTest, MakeEvpDigestContextSetsDeleter) {
-  auto context = MakeEvpDigestContext();
+  OpenSslEvpDigestContext context = MakeEvpDigestContext();
   ASSERT_THAT(context, NotNull());
   EXPECT_EQ(context.get_deleter(), &EVP_MD_CTX_free);
 }
 
 TEST(OpenSslStructsTest, MakeRsaSetsDeleter) {
-  auto rsa = MakeRsa();
+  OpenSslRsa rsa = MakeRsa();
   ASSERT_THAT(rsa, NotNull());
   EXPECT_EQ(rsa.get_deleter(), &RSA_free);
 }
 
 TEST(OpenSslStructsTest, MakeRsaMethodSetsDeleter) {
-  auto rsa_method = MakeRsaMethod("", 0);
+  OpenSslRsaMethod rsa_method = MakeRsaMethod("", 0);
   ASSERT_THAT(rsa_method, NotNull());
   EXPECT_EQ(rsa_method.get_deleter(), &RSA_meth_free);
 }
 
 TEST(OpenSslStructsTest, MakeRsaMethodSetsName) {
-  auto empty_name = MakeRsaMethod("", 0);
+  OpenSslRsaMethod empty_name = MakeRsaMethod("", 0);
   ASSERT_THAT(empty_name, NotNull());
   EXPECT_STREQ(RSA_meth_get0_name(empty_name.get()), "");
 
-  auto some_name = MakeRsaMethod("my-name", 0);
+  OpenSslRsaMethod some_name = MakeRsaMethod("my-name", 0);
   ASSERT_THAT(some_name, NotNull());
   EXPECT_STREQ(RSA_meth_get0_name(some_name.get()), "my-name");
 }
 
 TEST(OpenSslStructsTest, MakeRsaMethodSetsFlags) {
-  auto with_flag = MakeRsaMethod("", RSA_FLAG_EXT_PKEY);
+  OpenSslRsaMethod with_flag = MakeRsaMethod("", RSA_FLAG_EXT_PKEY);
   ASSERT_THAT(with_flag, NotNull());
   EXPECT_TRUE(RSA_meth_get_flags(with_flag.get()) & RSA_FLAG_EXT_PKEY);
 
-  auto without_flag = MakeRsaMethod("", 0);
+  OpenSslRsaMethod without_flag = MakeRsaMethod("", 0);
   ASSERT_THAT(without_flag, NotNull());
   EXPECT_FALSE(RSA_meth_get_flags(without_flag.get()) & RSA_FLAG_EXT_PKEY);
 }

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -41,6 +41,23 @@ TEST(OpenSslMakeTest, MakeEcKeyMethodSetsDeleter) {
   EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
 }
 
+TEST(OpenSslMakeTest, MakeEcKeyMethodPerformsShallowCopy) {
+  const EC_KEY_METHOD *default_ec_key_method = EC_KEY_OpenSSL();
+
+  auto ec_key_method = MakeEcKeyMethod(default_ec_key_method);
+  ASSERT_THAT(ec_key_method, NotNull());
+  EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
+
+  EXPECT_EQ(EC_KEY_METHOD_get_init(ec_key_method.get()),
+            EC_KEY_METHOD_get_init(default_ec_key_method));
+  EXPECT_EQ(EC_KEY_METHOD_get_compute_key(ec_key_method.get()),
+            EC_KEY_METHOD_get_compute_key(default_ec_key_method));
+  EXPECT_EQ(EC_KEY_METHOD_get_sign(ec_key_method.get()),
+            EC_KEY_METHOD_get_sign(default_ec_key_method));
+  EXPECT_EQ(EC_KEY_METHOD_get_verify(ec_key_method.get()),
+            EC_KEY_METHOD_get_verify(default_ec_key_method));
+}
+
 TEST(OpenSslMakeTest, MakeEngineSetsDeleter) {
   auto engine = MakeEngine();
   ASSERT_THAT(engine, NotNull());

--- a/src/bridge/memory_util/openssl_structs_test.cc
+++ b/src/bridge/memory_util/openssl_structs_test.cc
@@ -48,10 +48,10 @@ TEST(OpenSslMakeTest, MakeEcKeyMethodPerformsShallowCopy) {
   ASSERT_THAT(ec_key_method, NotNull());
   EXPECT_EQ(ec_key_method.get_deleter(), &EC_KEY_METHOD_free);
 
-  int (*pkeygen)(EC_KEY *key) actual_keygen_function;
+  int (*actual_keygen_function)(EC_KEY *key) = nullptr;
   EC_KEY_METHOD_get_keygen(ec_key_method.get(), &actual_keygen_function);
 
-  int (*pkeygen)(EC_KEY *key) expected_keygen_function;
+  int (*expected_keygen_function)(EC_KEY *key) = nullptr;
   EC_KEY_METHOD_get_keygen(default_ec_key_method, &expected_keygen_function);
 
   EXPECT_EQ(actual_keygen_function, expected_keygen_function);


### PR DESCRIPTION
Adds more OpenSSL structs to `memory_util` to be used down the line (in key loader implementation, for example).

Also cleans up testing code for `openssl_structs.h`.