### PR TITLE
Fix failing ex_data_util tests caused by renaming RsaKey to CryptoKeyHandle

### DIFF
--- a/src/bridge/ex_data_util/BUILD
+++ b/src/bridge/ex_data_util/BUILD
@@ -41,7 +41,7 @@ cc_test(
         ":ex_data_util",
         "//src/bridge/memory_util:openssl_structs",
         "//src/testing_util:mock_client",
-        "//src/testing_util:mock_rsa_key",
+        "//src/testing_util:mock_crypto_key_handle",
         "//src/testing_util:test_matchers",
         "@com_google_googletest//:gtest_main",
     ],

--- a/src/bridge/ex_data_util/ex_data_util.cc
+++ b/src/bridge/ex_data_util/ex_data_util.cc
@@ -22,7 +22,7 @@
 #include <openssl/rsa.h>
 #include <openssl/x509.h>
 
-#include "src/backing/rsa/rsa_key.h"
+#include "src/backing/crypto_key_handle/crypto_key_handle.h"
 #include "src/backing/status/status.h"
 #include "src/backing/status/status_or.h"
 #include "src/bridge/ex_data_util/engine_data.h"

--- a/src/bridge/ex_data_util/ex_data_util.cc
+++ b/src/bridge/ex_data_util/ex_data_util.cc
@@ -31,13 +31,15 @@ namespace kmsengine {
 namespace bridge {
 namespace {
 
+using ::kmsengine::backing::CryptoKeyHandle;
+
 // Represents an uninitialized OpenSSL external index. Value is -1 since
 // OpenSSL's `CRYPTO_get_ex_new_index` function for requesting external indices
 // returns -1 on failure.
 static constexpr int kUninitializedIndex = -1;
 
 // External index assigned by OpenSSL on a `RSA` struct. If uninitialized, it
-// has value `kUninitializedIndex`. Used in `AttachRsaKeyToOpenSslRsa` and
+// has value `kUninitializedIndex`. Used in `AttachCryptoKeyHandleToOpenSslRsa` and
 // `GetRsaKeyFromOpenSslRsa`.
 static int rsa_index = kUninitializedIndex;
 
@@ -95,7 +97,7 @@ void FreeExternalIndices() {
   engine_index = kUninitializedIndex;
 }
 
-Status AttachRsaKeyToOpenSslRsa(backing::RsaKey *rsa_key, RSA *rsa) {
+Status AttachCryptoKeyHandleToOpenSslRsa(CryptoKeyHandle *rsa_key, RSA *rsa) {
   if (rsa == nullptr) {
     return Status(StatusCode::kInvalidArgument, "RSA cannot be null");
   }
@@ -107,7 +109,7 @@ Status AttachRsaKeyToOpenSslRsa(backing::RsaKey *rsa_key, RSA *rsa) {
   return Status::kOk;
 }
 
-StatusOr<backing::RsaKey *> GetRsaKeyFromOpenSslRsa(const RSA *rsa) {
+StatusOr<CryptoKeyHandle *> GetRsaKeyFromOpenSslRsa(const RSA *rsa) {
   if (rsa == nullptr) {
     return Status(StatusCode::kInvalidArgument, "RSA cannot be null");
   }
@@ -118,7 +120,7 @@ StatusOr<backing::RsaKey *> GetRsaKeyFromOpenSslRsa(const RSA *rsa) {
     return Status(StatusCode::kNotFound,
                   "RSA instance was not initialized with Cloud KMS data");
   }
-  return static_cast<backing::RsaKey *>(ex_data);
+  return static_cast<CryptoKeyHandle *>(ex_data);
 }
 
 Status AttachEngineDataToOpenSslEngine(EngineData *data, ENGINE *engine) {

--- a/src/bridge/ex_data_util/ex_data_util.cc
+++ b/src/bridge/ex_data_util/ex_data_util.cc
@@ -39,8 +39,8 @@ using ::kmsengine::backing::CryptoKeyHandle;
 static constexpr int kUninitializedIndex = -1;
 
 // External index assigned by OpenSSL on a `RSA` struct. If uninitialized, it
-// has value `kUninitializedIndex`. Used in `AttachCryptoKeyHandleToOpenSslRsa` and
-// `GetRsaKeyFromOpenSslRsa`.
+// has value `kUninitializedIndex`. Used in `AttachCryptoKeyHandleToOpenSslRsa`
+// and `GetCryptoKeyHandleFromOpenSslRsa`.
 static int rsa_index = kUninitializedIndex;
 
 // External index assigned by OpenSSL on a `ENGINE` struct. If uninitialized, it
@@ -109,7 +109,7 @@ Status AttachCryptoKeyHandleToOpenSslRsa(CryptoKeyHandle *rsa_key, RSA *rsa) {
   return Status::kOk;
 }
 
-StatusOr<CryptoKeyHandle *> GetRsaKeyFromOpenSslRsa(const RSA *rsa) {
+StatusOr<CryptoKeyHandle *> GetCryptoKeyHandleFromOpenSslRsa(const RSA *rsa) {
   if (rsa == nullptr) {
     return Status(StatusCode::kInvalidArgument, "RSA cannot be null");
   }

--- a/src/bridge/ex_data_util/ex_data_util.h
+++ b/src/bridge/ex_data_util/ex_data_util.h
@@ -40,21 +40,23 @@ Status InitExternalIndices();
 // Frees the ex_data indices requested from OpenSSL.
 void FreeExternalIndices();
 
-// Attaches an `RsaKey` instance to the OpenSSL `RSA` instance. Returns an
+// Attaches an `CryptoKeyHandle` instance to the OpenSSL `RSA` instance. Returns an
 // error `Status` if an error occurred.
 //
 // `rsa_key` may be null (for example, to reset attached data when freeing
-// a previously-attached `RsaKey` to avoid use-after-free errors). `rsa` may
+// a previously-attached `CryptoKeyHandle` to avoid use-after-free errors). `rsa` may
 // not be null.
-Status AttachRsaKeyToOpenSslRsa(backing::CryptoKeyHandle *rsa_key, RSA *rsa);
+Status AttachCryptoKeyHandleToOpenSslRsa(backing::CryptoKeyHandle *rsa_key,
+                                         RSA *rsa);
 
-// Returns a raw pointer to the `RsaKey` instance attacked to the given
+// Returns a raw pointer to the `CryptoKeyHandle` instance attacked to the given
 // OpenSSL `RSA` struct. Raw pointer will never be null (if the underlying
 // external data is null, then an error `Status` is returned.)
 //
-// Attached data is only defined by a previous call to `AttachRsaKeyToRSA`.
-// `rsa` may not be null.
-StatusOr<backing::CryptoKeyHandle *> GetRsaKeyFromOpenSslRsa(const RSA *rsa);
+// Attached data is only defined by a previous call to
+// `AttachCryptoKeyHandleToOpenSslRsa`. `rsa` may not be null.
+StatusOr<backing::CryptoKeyHandle *> GetCryptoKeyHandleFromOpenSslRsa(
+    const RSA *rsa);
 
 // Attaches an `Client` instance to the OpenSSL `RSA` instance. Returns an
 // error `Status` if an error occurred.

--- a/src/bridge/ex_data_util/ex_data_util.h
+++ b/src/bridge/ex_data_util/ex_data_util.h
@@ -20,7 +20,7 @@
 #include <openssl/engine.h>
 #include <openssl/rsa.h>
 
-#include "src/backing/rsa/rsa_key.h"
+#include "src/backing/crypto_key_handle/crypto_key_handle.h"
 #include "src/backing/status/status.h"
 #include "src/backing/status/status_or.h"
 #include "src/bridge/ex_data_util/engine_data.h"

--- a/src/bridge/ex_data_util/ex_data_util.h
+++ b/src/bridge/ex_data_util/ex_data_util.h
@@ -46,7 +46,7 @@ void FreeExternalIndices();
 // `rsa_key` may be null (for example, to reset attached data when freeing
 // a previously-attached `RsaKey` to avoid use-after-free errors). `rsa` may
 // not be null.
-Status AttachRsaKeyToOpenSslRsa(backing::RsaKey *rsa_key, RSA *rsa);
+Status AttachRsaKeyToOpenSslRsa(backing::CryptoKeyHandle *rsa_key, RSA *rsa);
 
 // Returns a raw pointer to the `RsaKey` instance attacked to the given
 // OpenSSL `RSA` struct. Raw pointer will never be null (if the underlying
@@ -54,7 +54,7 @@ Status AttachRsaKeyToOpenSslRsa(backing::RsaKey *rsa_key, RSA *rsa);
 //
 // Attached data is only defined by a previous call to `AttachRsaKeyToRSA`.
 // `rsa` may not be null.
-StatusOr<backing::RsaKey *> GetRsaKeyFromOpenSslRsa(const RSA *rsa);
+StatusOr<backing::CryptoKeyHandle *> GetRsaKeyFromOpenSslRsa(const RSA *rsa);
 
 // Attaches an `Client` instance to the OpenSSL `RSA` instance. Returns an
 // error `Status` if an error occurred.

--- a/src/bridge/ex_data_util/ex_data_util_test.cc
+++ b/src/bridge/ex_data_util/ex_data_util_test.cc
@@ -27,31 +27,31 @@ namespace kmsengine {
 namespace bridge {
 namespace {
 
-using ::kmsengine::backing::RsaKey;
+using ::kmsengine::backing::CryptoKeyHandle;
 using ::kmsengine::testing_util::IsOk;
-using ::kmsengine::testing_util::MockRsaKey;
+using ::kmsengine::testing_util::MockCryptoKeyHandle;
 using ::testing::Not;
 
-TEST(ExDataUtilTest, RsaKeyRoundtrip) {
+TEST(ExDataUtilTest, CryptoKeyHandleRoundtrip) {
   ASSERT_THAT(InitExternalIndices(), IsOk());
 
   OpenSslRsa rsa = MakeRsa();
-  MockRsaKey rsa_key;
-  ASSERT_THAT(AttachRsaKeyToOpenSslRsa(&rsa_key, rsa.get()), IsOk());
+  MockCryptoKeyHandle rsa_key;
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(&rsa_key, rsa.get()), IsOk());
 
-  StatusOr<RsaKey *> actual = GetRsaKeyFromOpenSslRsa(rsa.get());
+  StatusOr<CryptoKeyHandle *> actual = GetCryptoKeyHandleFromOpenSslRsa(rsa.get());
   EXPECT_THAT(actual, IsOk());
   EXPECT_EQ(actual.value(), &rsa_key);
 
   FreeExternalIndices();
 }
 
-TEST(ExDataUtilTest, HandlesNullRsaKey) {
+TEST(ExDataUtilTest, HandlesNullCryptoKeyHandle) {
   ASSERT_THAT(InitExternalIndices(), IsOk());
 
   OpenSslRsa rsa = MakeRsa();
-  ASSERT_THAT(AttachRsaKeyToOpenSslRsa(nullptr, rsa.get()), IsOk());
-  EXPECT_THAT(GetRsaKeyFromOpenSslRsa(rsa.get()), Not(IsOk()));
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(nullptr, rsa.get()), IsOk());
+  EXPECT_THAT(GetCryptoKeyHandleFromOpenSslRsa(rsa.get()), Not(IsOk()));
 
   FreeExternalIndices();
 }
@@ -59,10 +59,12 @@ TEST(ExDataUtilTest, HandlesNullRsaKey) {
 TEST(ExDataUtilTest, ReturnsErrorOnNullRsa) {
   ASSERT_THAT(InitExternalIndices(), IsOk());
 
-  MockRsaKey rsa_key;
-  ASSERT_THAT(AttachRsaKeyToOpenSslRsa(&rsa_key, nullptr), Not(IsOk()));
-  ASSERT_THAT(AttachRsaKeyToOpenSslRsa(nullptr, nullptr), Not(IsOk()));
-  EXPECT_THAT(GetRsaKeyFromOpenSslRsa(nullptr), Not(IsOk()));
+  MockCryptoKeyHandle rsa_key;
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(&rsa_key, nullptr),
+              Not(IsOk()));
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(nullptr, nullptr),
+              Not(IsOk()));
+  EXPECT_THAT(GetCryptoKeyHandleFromOpenSslRsa(nullptr), Not(IsOk()));
 
   FreeExternalIndices();
 }
@@ -70,12 +72,14 @@ TEST(ExDataUtilTest, ReturnsErrorOnNullRsa) {
 TEST(ExDataUtilTest, ReturnsErrorWhenRsaExternalIndiciesNotInitialized) {
   // Explicitly not calling `InitExternalIndices` here.
   OpenSslRsa rsa = MakeRsa();
-  MockRsaKey rsa_key;
+  MockCryptoKeyHandle rsa_key;
 
-  EXPECT_THAT(AttachRsaKeyToOpenSslRsa(&rsa_key, rsa.get()), Not(IsOk()));
-  EXPECT_THAT(AttachRsaKeyToOpenSslRsa(nullptr, rsa.get()), Not(IsOk()));
+  EXPECT_THAT(AttachCryptoKeyHandleToOpenSslRsa(&rsa_key, rsa.get()),
+              Not(IsOk()));
+  EXPECT_THAT(AttachCryptoKeyHandleToOpenSslRsa(nullptr, rsa.get()),
+              Not(IsOk()));
 
-  EXPECT_THAT(GetRsaKeyFromOpenSslRsa(rsa.get()), Not(IsOk()));
+  EXPECT_THAT(GetCryptoKeyHandleFromOpenSslRsa(rsa.get()), Not(IsOk()));
 }
 
 TEST(ExDataUtilTest, EngineDataRoundtrip) {

--- a/src/bridge/ex_data_util/ex_data_util_test.cc
+++ b/src/bridge/ex_data_util/ex_data_util_test.cc
@@ -20,7 +20,7 @@
 #include "src/bridge/ex_data_util/ex_data_util.h"
 #include "src/bridge/memory_util/openssl_structs.h"
 #include "src/testing_util/mock_client.h"
-#include "src/testing_util/mock_rsa_key.h"
+#include "src/testing_util/mock_crypto_key_handle.h"
 #include "src/testing_util/test_matchers.h"
 
 namespace kmsengine {

--- a/src/testing_util/BUILD
+++ b/src/testing_util/BUILD
@@ -30,11 +30,11 @@ cc_library(
 )
 
 cc_library(
-    name = "mock_rsa_key",
-    hdrs = ["mock_rsa_key.h"],
+    name = "mock_crypto_key_handle",
+    hdrs = ["mock_crypto_key_handle.h"],
     deps = [
         "//src/backing/client:digest_case",
-        "//src/backing/rsa:rsa_key",
+        "//src/backing/crypto_key_handle",
         "//src/backing/status",
         "//src/backing/status:status_or",
         "@com_google_googletest//:gtest_main",

--- a/src/testing_util/mock_crypto_key_handle.h
+++ b/src/testing_util/mock_crypto_key_handle.h
@@ -22,15 +22,15 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "src/backing/rsa/rsa_key.h"
 #include "src/backing/client/digest_case.h"
 #include "src/backing/client/public_key.h"
+#include "src/backing/crypto_key_handle/crypto_key_handle.h"
 #include "src/backing/status/status_or.h"
 
 namespace kmsengine {
 namespace testing_util {
 
-class MockRsaKey : public ::kmsengine::backing::RsaKey {
+class MockCryptoKeyHandle : public ::kmsengine::backing::CryptoKeyHandle {
  public:
   MOCK_METHOD(StatusOr<std::string>, Sign,
               (::kmsengine::backing::DigestCase type,

--- a/src/testing_util/mock_crypto_key_handle.h
+++ b/src/testing_util/mock_crypto_key_handle.h
@@ -32,6 +32,7 @@ namespace testing_util {
 
 class MockCryptoKeyHandle : public ::kmsengine::backing::CryptoKeyHandle {
  public:
+  MOCK_METHOD(std::string, key_resource_id, (), (const, override));
   MOCK_METHOD(StatusOr<std::string>, Sign,
               (::kmsengine::backing::DigestCase type,
                std::string message_digest),


### PR DESCRIPTION
Resolves #105.