### PR TITLE
Fix symbol conflicts by allowlisting visibility of backing layer symbols

### DIFF
--- a/bazel/cc_binary_with_global_copts.bzl
+++ b/bazel/cc_binary_with_global_copts.bzl
@@ -1,0 +1,120 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+This file defines a version of the Starlark-native `cc_binary` rule that
+supports an additional, optional `global_copts` attribute.
+
+`global_copts` is a list of strings representing compiler options to pass to
+the C++ compilation command. `global_copts` behaves similarly to the built-in
+`copts` attribute: each string in this attribute is added in the given order to
+`COPTS` before compiling the binary target. However, unlike `copts`, options
+passed in `global_copts` are propogated to the target's dependencies as well.
+"""
+
+# Implementation of `_copt_transition`.
+def _copt_transition_impl(settings, attr):
+    # `settings` provides read-only access to existing flags on the build.
+    # However, this transition won't read any flags (since the `inputs`
+    # attribute of `_copt_transition` is empty), so we can ignore it here.
+    _ignore = settings
+
+    # This adds all of the options specified in the owning rule's `global_copts`
+    # attribute as a compilation flag.
+    return {"//command_line_option:copt": attr.global_copts}
+
+# `_copt_transition` defines a Starlark transition that universally sets
+# `//command_line_option:copt` to the list of options that are specified in the
+# owning rule's `global_copts` attribute.
+#
+# `inputs` is purposely empty as this transition does not need to read any
+# existing flags (it's only adding new ones).
+_copt_transition = transition(
+    implementation = _copt_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:copt"],
+)
+
+# Implementation of `cc_binary_with_global_copts_rule`. This copies the
+# `cc_binary`'s output to `cc_binary_with_global_copts_rule`'s own output, then
+# propogates its runfiles and executable back to Bazel. This makes
+# `cc_binary_with_global_copts_rule` as close to a pure wrapper of `cc_binary`
+# as possible.
+def _cc_binary_with_global_copts_rule_impl(ctx):
+    actual_binary = ctx.attr.actual_binary[0]
+    outfile = ctx.actions.declare_file(ctx.label.name)
+    cc_binary_outfile = actual_binary[DefaultInfo].files.to_list()[0]
+
+    ctx.actions.run_shell(
+        inputs = [cc_binary_outfile],
+        outputs = [outfile],
+        command = "cp %s %s" % (cc_binary_outfile.path, outfile.path),
+    )
+    return [
+        DefaultInfo(
+            executable = outfile,
+            runfiles = actual_binary[DefaultInfo].default_runfiles,
+        ),
+    ]
+
+# `cc_binary_with_global_copts_rule` consumes a `global_copts` attribute and
+# invokes a transition that sets `//command_line_option:copt` to the specified
+# list of strings in `global_copts`.
+cc_binary_with_global_copts_rule = rule(
+    implementation = _cc_binary_with_global_copts_rule_impl,
+    attrs = {
+        # This is where the user can set the feature they want.
+        "global_copts": attr.string_list(default = []),
+        # This is the cc_binary whose deps will select() on that feature.
+        # Note specificaly how it's configured with _copt_transition, which
+        # ensures that our `global_copts` propogate down the build graph.
+        "actual_binary": attr.label(cfg = _copt_transition),
+        # This is a stock Bazel requirement for any rule that uses Starlark
+        # transitions. The purpose of this requirement is to give the ability to
+        # restrict which packages can invoke these rules, since Starlark
+        # transitions make much larger graphs possible that can have memory and
+        # performance consequences for the build. The whitelist currently
+        # defaults to "everything".
+        "_whitelist_function_transition": attr.label(
+            default = "@bazel_tools//tools/whitelists/function_transition_whitelist",
+        ),
+    },
+    # Making this executable means it works with "$ bazel run".
+    executable = True,
+)
+
+# Convenience macro: this instantiates a `cc_binary_with_global_copts_rule` with
+# the given desired `global_copts`, instantiates a `cc_binary` as a dependency of
+# that rule, and fills out that `cc_binary` rule with all other parameters
+# passed to this macro.
+#
+# While `cc_binary_with_global_copts_rule` could directly be included in a BUILD
+# file, we define a `cc_binary` macro for convenience so the BUILD file can look
+# as close to normal as possible. The result is a wrapper over cc_binary that
+# "magically" gives it a new `global_copts` attribute. BUILD users who wish to
+# use this version of `cc_binary` need to `load(...)` this version at the top of
+# their BUILD file.
+def cc_binary(name, global_copts = None, **kwargs):
+    cc_binary_name = name + "_native_binary"
+    cc_binary_with_global_copts_rule(
+        name = name,
+        actual_binary = ":%s" % cc_binary_name,
+        global_copts = global_copts,
+    )
+    native.cc_binary(
+        name = cc_binary_name,
+        **kwargs
+    )

--- a/src/backing/BUILD
+++ b/src/backing/BUILD
@@ -56,11 +56,9 @@ cc_binary(
     deps = [
         ":export_macros",
         "//src/backing/client",
-        "//src/backing/client:client_factory",
         "//src/backing/client:crypto_key_version_algorithm",
         "//src/backing/client:digest_case",
         "//src/backing/client:public_key",
-        "//src/backing/client/grpc_client",
         "//src/backing/client/grpc_client:client_context_factory",
         "//src/backing/client/grpc_client:key_management_service_stub",
         "//src/backing/client/grpc_client:proto_util",

--- a/src/backing/BUILD
+++ b/src/backing/BUILD
@@ -14,13 +14,14 @@
 # limitations under the License.
 #
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_import", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
+load("//:bazel/cc_binary_with_global_copts.bzl", "cc_binary")
 
 package(default_visibility = ["//src:__subpackages__"])
 
 cc_import(
     name = "backing",
-    hdrs = [":headers"],
+    hdrs = [":bridge_headers"],
     shared_library = ":libkms.so",
 )
 
@@ -31,13 +32,35 @@ cc_binary(
         "//src/backing/crypto_key_handle:sources",
         "//src/backing/status:sources",
     ],
+    # `global_copts` is an attribute defined by the `cc_binary` macro from
+    # `cc_binary_with_global_copts.bzl`. These "global compiler options" are
+    # used to compile the entire `libkms.so` shared object with
+    # "-fvisibility=hidden", including dependencies.
+    #
+    # This custom version of `cc_binary` is used in lieu of the native Starlark
+    # `cc_binary` rule since the native `cc_binary` rule's `copts` attribute
+    # does not propogate compiler flags to the dependencies of the rule.
+    #
+    # By compiling all dependencies of the rule with "-fvisibility=hidden",
+    # we ensure that only the symbols explicitly allowlisted with the
+    # `KMSENGINE_EXPORT` macro are visible to the bridge layer. This needs
+    # to be done to avoid symbol conflicts between BoringSSL (used in the
+    # gRPC library in the backing layer) and OpenSSL (which the bridge layer
+    # links against).
+    #
+    # Minimizing the number of visible symbols has additional benefits; see
+    # https://gcc.gnu.org/wiki/Visibility for more information.
+    global_copts = ["-fvisibility=hidden"],
     linkshared = 1,
     linkstatic = 1,
     deps = [
+        ":export_macros",
         "//src/backing/client",
+        "//src/backing/client:client_factory",
         "//src/backing/client:crypto_key_version_algorithm",
         "//src/backing/client:digest_case",
         "//src/backing/client:public_key",
+        "//src/backing/client/grpc_client",
         "//src/backing/client/grpc_client:client_context_factory",
         "//src/backing/client/grpc_client:key_management_service_stub",
         "//src/backing/client/grpc_client:proto_util",
@@ -47,9 +70,15 @@ cc_binary(
     ],
 )
 
+cc_library(
+    name = "export_macros",
+    hdrs = ["export_macros.h"],
+)
+
 filegroup(
-    name = "headers",
+    name = "bridge_headers",
     srcs = [
+        "export_macros.h",
         "//src/backing/client:bridge_headers",
         "//src/backing/crypto_key_handle:bridge_headers",
         "//src/backing/status:bridge_headers",

--- a/src/backing/client/BUILD
+++ b/src/backing/client/BUILD
@@ -23,6 +23,7 @@ filegroup(
     name = "bridge_headers",
     srcs = [
         "client.h",
+        "client_factory.h",
         "crypto_key_version_algorithm.h",
         "digest_case.h",
         "public_key.h",
@@ -49,6 +50,7 @@ cc_library(
     deps = [
         ":digest_case",
         ":public_key",
+        "//src/backing:export_macros",
         "//src/backing/status",
         "//src/backing/status:status_or",
     ],
@@ -56,9 +58,10 @@ cc_library(
 
 cc_library(
     name = "digest_case",
-    hdrs = ["digest_case.h"],
     srcs = ["digest_case.cc"],
+    hdrs = ["digest_case.h"],
     deps = [
+        "//src/backing:export_macros",
         "@com_google_absl//absl/strings:str_format",
     ],
 )
@@ -79,6 +82,7 @@ cc_library(
     hdrs = ["public_key.h"],
     deps = [
         ":crypto_key_version_algorithm",
+        "//src/backing:export_macros",
     ],
 )
 
@@ -97,6 +101,7 @@ cc_library(
     srcs = ["crypto_key_version_algorithm.cc"],
     hdrs = ["crypto_key_version_algorithm.h"],
     deps = [
+        "//src/backing:export_macros",
         "@com_google_absl//absl/strings:str_format",
     ],
 )

--- a/src/backing/client/BUILD
+++ b/src/backing/client/BUILD
@@ -23,7 +23,6 @@ filegroup(
     name = "bridge_headers",
     srcs = [
         "client.h",
-        "client_factory.h",
         "crypto_key_version_algorithm.h",
         "digest_case.h",
         "public_key.h",

--- a/src/backing/client/client.h
+++ b/src/backing/client/client.h
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "src/backing/export_macros.h"
 #include "src/backing/client/digest_case.h"
 #include "src/backing/client/public_key.h"
 #include "src/backing/status/status.h"
@@ -28,7 +29,7 @@ namespace kmsengine {
 namespace backing {
 
 // Defines the interface used to communicate with the Google Cloud KMS API.
-class Client {
+class KMSENGINE_EXPORT Client {
  public:
   virtual ~Client() = default;
 

--- a/src/backing/client/crypto_key_version_algorithm.h
+++ b/src/backing/client/crypto_key_version_algorithm.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <type_traits>
 
+#include "src/backing/export_macros.h"
+
 namespace kmsengine {
 namespace backing {
 
@@ -35,7 +37,7 @@ namespace backing {
 // cases in `google::cloud::kms::v1::CryptoKeyVersionAlgorithm`; this allows for
 // simple conversions between `CryptoKeyVersionAlgorithm` and its protobuf
 // counterpart by using `static_cast`.
-enum class CryptoKeyVersionAlgorithm : int {
+enum class KMSENGINE_EXPORT CryptoKeyVersionAlgorithm : int {
   // Not specified.
   kAlgorithmUnspecified = 0,
   // Creates symmetric encryption keys.
@@ -80,8 +82,10 @@ constexpr int CryptoKeyVersionAlgorithmToInt(CryptoKeyVersionAlgorithm algo) {
 }
 
 // Converts a `CryptoKeyVersionAlgorithm` to a human-readable string.
-std::string CryptoKeyVersionAlgorithmToString(CryptoKeyVersionAlgorithm algo);
-std::ostream& operator<<(std::ostream& os, CryptoKeyVersionAlgorithm code);
+KMSENGINE_EXPORT std::string CryptoKeyVersionAlgorithmToString(
+    CryptoKeyVersionAlgorithm algo);
+KMSENGINE_EXPORT std::ostream& operator<<(std::ostream& os,
+                                          CryptoKeyVersionAlgorithm code);
 
 }  // namespace backing
 }  // namespace kmsengine

--- a/src/backing/client/digest_case.h
+++ b/src/backing/client/digest_case.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <type_traits>
 
+#include "src/backing/export_macros.h"
+
 namespace kmsengine {
 namespace backing {
 
@@ -34,7 +36,7 @@ namespace backing {
 // cases in `google::cloud::kms::v1::Digest::DigestCase`; this allows for
 // simple conversions between `DigestCase` and its protobuf counterpart by
 // using `static_cast`.
-enum class DigestCase : int {
+enum class KMSENGINE_EXPORT DigestCase : int {
   kSha256 = 1,
   kSha384 = 2,
   kSha512 = 3,
@@ -46,8 +48,9 @@ constexpr int DigestCaseToInt(DigestCase digest) {
 }
 
 // Converts a `DigestCase` to a human-readable string.
-std::string DigestCaseToString(DigestCase digest_case);
-std::ostream& operator<<(std::ostream& os, DigestCase digest_case);
+KMSENGINE_EXPORT std::string DigestCaseToString(DigestCase digest_case);
+KMSENGINE_EXPORT std::ostream& operator<<(std::ostream& os,
+                                          DigestCase digest_case);
 
 }  // namespace backing
 }  // namespace kmsengine

--- a/src/backing/client/public_key.h
+++ b/src/backing/client/public_key.h
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "src/backing/export_macros.h"
 #include "src/backing/client/crypto_key_version_algorithm.h"
 
 namespace kmsengine {
@@ -30,7 +31,7 @@ namespace backing {
 // protobuf definitions since the bridge layer needs to refer to this resource
 // directly and the bridge layer is not able to include external dependencies
 // (such as the generated protobuf definitions).
-class PublicKey {
+class KMSENGINE_EXPORT PublicKey {
  public:
   explicit PublicKey(std::string pem, CryptoKeyVersionAlgorithm algorithm)
       : pem_(pem), algorithm_(algorithm) {}

--- a/src/backing/crypto_key_handle/BUILD
+++ b/src/backing/crypto_key_handle/BUILD
@@ -43,6 +43,7 @@ cc_library(
     srcs = ["crypto_key_handle.cc"],
     hdrs = ["crypto_key_handle.h"],
     deps = [
+        "//src/backing:export_macros",
         "//src/backing/client",
         "//src/backing/client:digest_case",
         "//src/backing/client:public_key",

--- a/src/backing/crypto_key_handle/crypto_key_handle.h
+++ b/src/backing/crypto_key_handle/crypto_key_handle.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 
+#include "src/backing/export_macros.h"
 #include "src/backing/client/client.h"
 #include "src/backing/client/digest_case.h"
 #include "src/backing/client/public_key.h"
@@ -47,7 +48,7 @@ namespace backing {
 // associated `CryptoKeyHandle` methods. This is because some conversions
 // require knowledge of symbols from the OpenSSL library (which are not
 // visible to the backing layer).
-class CryptoKeyHandle {
+class KMSENGINE_EXPORT CryptoKeyHandle {
  public:
   virtual ~CryptoKeyHandle() = default;
 
@@ -67,7 +68,7 @@ class CryptoKeyHandle {
 };
 
 // Creates a `unique_ptr` containing a `CryptoKeyHandle` implementation.
-StatusOr<std::unique_ptr<CryptoKeyHandle>> MakeCryptoKeyHandle(
+KMSENGINE_EXPORT StatusOr<std::unique_ptr<CryptoKeyHandle>> MakeCryptoKeyHandle(
     std::string const& key_resource_id, Client const& client);
 
 }  // namespace backing

--- a/src/backing/export_macros.h
+++ b/src/backing/export_macros.h
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BACKING_EXPORT_MACROS_H_
+#define KMSENGINE_BACKING_EXPORT_MACROS_H_
+
+// To avoid symbol conflicts between the backing layer and the bridge layer,
+// this file defines two macros used to declare which symbols defined in the
+// backing layer are "visible" to the bridge layer:
+//
+//    - KMSENGINE_EXPORT, which declares that a particular symbol should be made
+//      visible to the bridge layer.
+//
+//    - KMSENGINE_LOCAL, which declares that a particular symbol is only
+//      internally used and should not be made visible to the bridge layer.
+//
+// These macros are intended to be used in conjunction with the
+// "-fvisibility=hidden" compiler flag, which tells the C++ compiler that every
+// declaration not explicitly marked with a visibility attribute has a "hidden"
+// visibility (equivalent to marking the symbol with the KMSENGINE_LOCAL macro).
+// The Bazel rule for building the backing layer shared object builds the shared
+// object with the "-fvisibility=hidden" flag enabled across the entire build.
+//
+// Classes and enums that need to be referenced in the bridge layer should be
+// marked with KMSENGINE_EXPORT.
+//
+//    Example:
+//
+//        class KMSENGINE_EXPORT MyClass { ... };
+//
+//        enum KMSENGINE_EXPORT MyEnum { ... };
+//
+// Functions that need to be marked with KMSENGINE_EXPORT are those that satisfy
+// the following conditions:
+//
+//    1) The function is expected to be called from the bridge layer.
+//
+//    2) The function's implementation is declared in a source file (not a
+//       header file). Any functions declared in a header file that is #included
+//       by the bridge layer will be visible to the bridge layer as the
+//       implementation of the function is directly in the header file.
+//       Pure virtual functions or functions declared to have "default"
+//       implementation do not need to be marked with KMSENGINE_EXPORT.
+//
+//    Example:
+//
+//        KMSENGINE_EXPORT int MyFunction(...) { ... }
+//
+// In general, marking functions with KMSENGINE_LOCAL is not necessary due to
+// the global usage of the "-fvisibility=hidden" flag described above. However,
+// there is one case in which explicitly marking a function with KMSENGINE_LOCAL
+// is useful: individual member functions of an exported class that are not
+// part of the interface (in particular, ones which are private), and are not
+// used by friend code, should be marked individually with KMSENGINE_LOCAL. This
+// allows the compiler to generate more optimal code and results in a smaller
+// library size.
+//
+//    Example:
+//
+//        class KMSENGINE_EXPORT MyExportedClass {
+//         public:
+//          ...
+//
+//         private:
+//          KMSENGINE_LOCAL int MyPrivateFunction(...) { ... }
+//
+//          // Member variables should not be marked with KMSENGINE_LOCAL; the
+//          // compiler will ignore visibility declarations on member variables.
+//          std::string my_member_variable_;
+//        }
+//
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_DLL
+    #ifdef __GNUC__
+      #define KMSENGINE_EXPORT __attribute__ ((dllexport))
+    #else
+      #define KMSENGINE_EXPORT __declspec(dllexport)
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define KMSENGINE_EXPORT __attribute__ ((dllimport))
+    #else
+      #define KMSENGINE_EXPORT __declspec(dllimport)
+    #endif
+  #endif
+  #define KMSENGINE_LOCAL
+#else
+  #if __GNUC__ >= 4
+    #define KMSENGINE_EXPORT __attribute__ ((visibility ("default")))
+    #define KMSENGINE_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else
+    #define KMSENGINE_EXPORT
+    #define KMSENGINE_LOCAL
+  #endif
+#endif
+
+#endif  // KMSENGINE_BACKING_EXPORT_MACROS_H_

--- a/src/backing/export_macros.h
+++ b/src/backing/export_macros.h
@@ -82,6 +82,7 @@
 //          std::string my_member_variable_;
 //        }
 //
+// See https://gcc.gnu.org/wiki/Visibility for more information.
 
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef BUILDING_DLL

--- a/src/backing/status/BUILD
+++ b/src/backing/status/BUILD
@@ -41,6 +41,7 @@ cc_library(
     hdrs = ["status_or.h"],
     deps = [
         ":status",
+        "//src/backing:export_macros",
     ],
 )
 
@@ -59,6 +60,9 @@ cc_library(
     name = "status",
     srcs = ["status.cc"],
     hdrs = ["status.h"],
+    deps = [
+        "//src/backing:export_macros",
+    ],
 )
 
 cc_test(

--- a/src/backing/status/status.h
+++ b/src/backing/status/status.h
@@ -36,6 +36,8 @@
 #include <iostream>
 #include <tuple>
 
+#include "src/backing/export_macros.h"
+
 namespace kmsengine {
 
 /**
@@ -44,7 +46,7 @@ namespace kmsengine {
  * The semantics of these values are documented in:
  *     https://grpc.io/grpc/cpp/classgrpc_1_1_status.html
  */
-enum class StatusCode {
+enum class KMSENGINE_EXPORT StatusCode {
   /// Not an error; returned on success.
   kOk = 0,
   kCancelled = 1,
@@ -69,8 +71,8 @@ inline int StatusCodeToInt(StatusCode code) {
   return static_cast<std::underlying_type<StatusCode>::type>(code);
 }
 
-std::string StatusCodeToString(StatusCode code);
-std::ostream& operator<<(std::ostream& os, StatusCode code);
+KMSENGINE_EXPORT std::string StatusCodeToString(StatusCode code);
+KMSENGINE_EXPORT std::ostream& operator<<(std::ostream& os, StatusCode code);
 
 /**
  * Reports error code and details from a remote request.
@@ -78,15 +80,12 @@ std::ostream& operator<<(std::ostream& os, StatusCode code);
  * This class is modeled after `grpc::Status`, it contains the status code and
  * error message (if applicable) from a JSON request.
  */
-class Status {
+class KMSENGINE_EXPORT Status {
  public:
   Status() = default;
 
   explicit Status(StatusCode status_code, std::string message)
       : code_(status_code), message_(std::move(message)) {}
-
-  // "OK" status for convenience.
-  static const Status kOk;
 
   bool ok() const { return code_ == StatusCode::kOk; }
 

--- a/src/backing/status/status.h
+++ b/src/backing/status/status.h
@@ -87,6 +87,9 @@ class KMSENGINE_EXPORT Status {
   explicit Status(StatusCode status_code, std::string message)
       : code_(status_code), message_(std::move(message)) {}
 
+  // "OK" status for convenience.
+  static const Status kOk;
+
   bool ok() const { return code_ == StatusCode::kOk; }
 
   StatusCode code() const { return code_; }

--- a/src/backing/status/status_or.h
+++ b/src/backing/status/status_or.h
@@ -33,10 +33,11 @@
 #ifndef KMSENGINE_BACKING_STATUS_STATUS_OR_H_
 #define KMSENGINE_BACKING_STATUS_STATUS_OR_H_
 
-#include "src/backing/status/status.h"
-
 #include <type_traits>
 #include <utility>
+
+#include "src/backing/export_macros.h"
+#include "src/backing/status/status.h"
 
 namespace kmsengine {
 /**
@@ -99,7 +100,7 @@ namespace kmsengine {
  * @tparam T the type of the value.
  */
 template <typename T>
-class StatusOr final {
+class KMSENGINE_EXPORT StatusOr final {
  public:
   /**
    * Initializes with an error status (UNKNOWN).
@@ -306,14 +307,14 @@ class StatusOr final {
   //@}
 
  private:
-  void CheckHasValue() const& {
+  KMSENGINE_LOCAL void CheckHasValue() const& {
     if (!ok()) {
       std::abort();
     }
   }
 
   // When possible, do not copy the status.
-  void CheckHasValue() && {
+  KMSENGINE_LOCAL void CheckHasValue() && {
     if (!ok()) {
       std::abort();
     }

--- a/src/bridge/BUILD
+++ b/src/bridge/BUILD
@@ -41,10 +41,6 @@ cc_test(
     name = "engine_bind_test",
     size = "small",
     srcs = ["engine_bind_test.cc"],
-    # Statically link in libcrypto in test environment only to avoid symbol
-    # issues with BoringSSL which only appear in the test environment.
-    linkstatic = True,
-    linkopts = ["-l:libcrypto.a", "-ldl"],
     deps = [
         ":engine_bind",
         "@com_google_googletest//:gtest_main",

--- a/src/bridge/error/BUILD
+++ b/src/bridge/error/BUILD
@@ -33,10 +33,6 @@ cc_test(
     name = "error_test",
     size = "small",
     srcs = ["error_test.cc"],
-    # Statically link in libcrypto in test environment only to avoid symbol
-    # issues with BoringSSL which only appear in the test environment.
-    linkstatic = True,
-    linkopts = ["-l:libcrypto.a", "-ldl"],
     deps = [
         ":error",
         "//src/testing_util:test_matchers",

--- a/src/bridge/ex_data_util/BUILD
+++ b/src/bridge/ex_data_util/BUILD
@@ -33,10 +33,6 @@ cc_test(
     name = "ex_data_util_test",
     size = "small",
     srcs = ["ex_data_util_test.cc"],
-    # TODO(zesp): Remove when https://github.com/googleinterns/cloud-kms-oss-tools/pull/84/
-    # is merged in.
-    linkstatic = True,
-    linkopts = ["-l:libcrypto.a", "-ldl"],
     deps = [
         ":ex_data_util",
         "//src/bridge/memory_util:openssl_structs",


### PR DESCRIPTION
Resolves #80. 

Builds the backing layer with `-fvisibility=hidden`. To do this, defines a new Starlark transition for the Bazel build rule for the backing layer shared object. Then, defines a set of `KMSENGINE_EXPORT` macros for explicitly allowlisting symbols from the backing layer to be visible to the bridge layer.