### PR TITLE
Make StatusCodeToInt constexpr

### DIFF
--- a/src/backing/status/status.h
+++ b/src/backing/status/status.h
@@ -65,7 +65,7 @@ enum class StatusCode {
   kDataLoss = 15,
 };
 
-inline int StatusCodeToInt(StatusCode code) {
+constexpr int StatusCodeToInt(StatusCode code) {
   return static_cast<std::underlying_type<StatusCode>::type>(code);
 }
 


### PR DESCRIPTION
Tiny PR to make `StatusCodeToInt` constexpr (simply because it can be defined as such).