### PR TITLE
Add OpenSSL callbacks for RSA operations

### DIFF
--- a/src/bridge/crypto/BUILD
+++ b/src/bridge/crypto/BUILD
@@ -36,12 +36,9 @@ cc_test(
     name = "rsa_test",
     size = "small",
     srcs = ["rsa_test.cc"],
-    # Statically link in libcrypto in test environment only to avoid symbol
-    # issues with BoringSSL which only appear in the test environment.
-    linkstatic = True,
-    linkopts = ["-l:libcrypto.a", "-ldl"],
     deps = [
         ":rsa",
+        "//src/bridge/memory_util:openssl_bio",
         "//src/testing_util:mock_crypto_key_handle",
         "//src/testing_util:openssl_assertions",
         "//src/testing_util:test_matchers",

--- a/src/bridge/crypto/BUILD
+++ b/src/bridge/crypto/BUILD
@@ -36,6 +36,10 @@ cc_test(
     name = "rsa_test",
     size = "small",
     srcs = ["rsa_test.cc"],
+    # Statically link in libcrypto in test environment only to avoid symbol
+    # issues with BoringSSL which only appear in the test environment.
+    linkstatic = True,
+    linkopts = ["-l:libcrypto.a", "-ldl"],
     deps = [
         ":rsa",
         "//src/testing_util:mock_crypto_key_handle",

--- a/src/bridge/crypto/BUILD
+++ b/src/bridge/crypto/BUILD
@@ -1,0 +1,46 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+package(default_visibility = ["//src/bridge:__subpackages__"])
+
+cc_library(
+    name = "rsa",
+    srcs = ["rsa.cc"],
+    hdrs = ["rsa.h"],
+    linkopts = ["-lcrypto"],
+    deps = [
+        "//src/backing",
+        "//src/bridge/error",
+        "//src/bridge/ex_data_util",
+        "//src/bridge/memory_util:openssl_structs",
+        "//src/bridge/nid_util",
+    ],
+)
+
+cc_test(
+    name = "rsa_test",
+    size = "small",
+    srcs = ["rsa_test.cc"],
+    deps = [
+        ":rsa",
+        "//src/testing_util:mock_crypto_key_handle",
+        "//src/testing_util:openssl_assertions",
+        "//src/testing_util:test_matchers",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/bridge/crypto/rsa.cc
+++ b/src/bridge/crypto/rsa.cc
@@ -144,7 +144,9 @@ int Verify(int type, const unsigned char *m, unsigned int m_len,
            const unsigned char *sigbuf, unsigned int siglen, const RSA *rsa) {
   // TODO(https://github.com/googleinterns/cloud-kms-oss-tools/issues/101):
   // This method is currently purposely left unimplemented, but it may need to
-  // be implemented at some point in the future.
+  // be implemented at some point in the future. The OpenSSL CLI seems to use
+  // RSA_public_decrypt over RSA_verify, so this never really gets called at the
+  // moment.
   KMSENGINE_SIGNAL_ERROR(
       Status(StatusCode::kUnimplemented, "Unsupported operation"));
   return false;
@@ -226,8 +228,8 @@ OpenSslRsaMethod MakeKmsRsaMethod() {
       // method. The OpenSSL man page for RSA_set_method(3) explicitly
       // permits these callbacks to be set to null in an engine implementation.
       // However, we are defining them here to be the OpenSSL defaults since
-      // the OpenSSL command-line utilities apparently require them to be
-      // defined in order for verification operations to work.
+      // the OpenSSL command-line utilities apparently use them for verification
+      // operations.
       !RSA_meth_set_mod_exp(rsa_method.get(),
                             RSA_meth_get_mod_exp(openssl_rsa_method)) ||
       !RSA_meth_set_bn_mod_exp(rsa_method.get(),

--- a/src/bridge/crypto/rsa.cc
+++ b/src/bridge/crypto/rsa.cc
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/bridge/crypto/rsa.h"
+
+#include <openssl/rsa.h>
+
+#include "src/backing/crypto_key_handle/crypto_key_handle.h"
+#include "src/backing/status/status.h"
+#include "src/bridge/error/error.h"
+#include "src/bridge/ex_data_util/ex_data_util.h"
+#include "src/bridge/memory_util/openssl_structs.h"
+#include "src/bridge/nid_util/nid_util.h"
+
+namespace kmsengine {
+namespace bridge {
+namespace crypto {
+namespace {
+
+using ::kmsengine::backing::CryptoKeyHandle;
+using ::kmsengine::backing::DigestCase;
+
+// Wrapper around error-checking and `reinterpret_cast` to make a std::string
+// representing a digest passed from OpenSSL as an unsigned char pointer and
+// length.
+StatusOr<std::string> MakeDigestString(const unsigned char *m,
+                                       const unsigned int m_length) {
+  if (m == nullptr) {
+    return Status(StatusCode::kInvalidArgument,
+                  "Message digest pointer cannot be null");
+  }
+  if (m_length == 0) {
+    return Status(StatusCode::kInvalidArgument,
+                  "Message digest length cannot be zero");
+  }
+
+  return std::string(reinterpret_cast<const char *>(m), m_length);
+}
+
+// Called when OpenSSL's `RSA_new_method` is called to initialize a new
+// `RSA` struct using the Cloud KMS engine.
+//
+// This is a no-op, as the key loader function is responsible for initializing
+// RSA structs to have meaningful engine-specific data. While some engine
+// implementations set the `init` callback to a null pointer, the OpenSSL
+// specification does not explicitly permit this function to be null in an
+// engine's `RSA_METHOD` implementation, so we define it as a no-op here.
+//
+// Returns 1 on success; otherwise, returns 0.
+int Init(RSA *rsa) {
+  return true;
+}
+
+// Cleans up any internal structures associated with the input `rsa` struct
+// (except for the RSA struct itself, which will be cleaned up by the OpenSSL
+// library).
+//
+// Called when OpenSSL's `RSA_free` is called on `rsa`. (See the OpenSSL man
+// page for RSA_free(3) for more information.)
+//
+// Returns 1 on success; otherwise, returns 0.
+int Finish(RSA *rsa) {
+  // `crypto_key_handle` is guaranteed to be non-null here (if the underlying
+  // external data struct was null, an error status would be returned).
+  KMSENGINE_ASSIGN_OR_RETURN_WITH_OPENSSL_ERROR(
+      const CryptoKeyHandle *crypto_key_handle,
+      GetCryptoKeyHandleFromOpenSslRsa(rsa), false);
+  delete crypto_key_handle;
+
+  Status status = AttachCryptoKeyHandleToOpenSslRsa(nullptr, rsa);
+  if (!status.ok()) {
+    KMSENGINE_SIGNAL_ERROR(status);
+  }
+  return status.ok();
+}
+
+// Signs the message digest `digest_bytes` of length `digest_length` using the
+// RSA private key represented by the OpenSSL RSA struct `rsa`. Then, stores the
+// resulting signature in `signature_return` and the signature size in
+// `signature_length`. The caller is responsible for ensuring that
+// `signature_return` points to `RSA_size(rsa)` bytes of memory. (See the
+// OpenSSL man page for RSA_sign(3) for more information.)
+//
+// Returns 1 on success; otherwise, returns 0.
+//
+// The function signature comes from the prototype for `RSA_meth_set_sign` from
+// the OpenSSL API.
+int Sign(int type, const unsigned char *digest_bytes,
+         unsigned int digest_length, unsigned char *signature_return,
+         unsigned int *signature_length, const RSA *rsa) {
+  // Convert arguments to engine-native structures for convenience. These
+  // conversions need to take place within the bridge layer (as opposed to
+  // letting the `RsaKey::Sign` method handling the conversions) since the
+  // conversion functions refer to some OpenSSL API functions.
+  KMSENGINE_ASSIGN_OR_RETURN_WITH_OPENSSL_ERROR(
+      const CryptoKeyHandle *crypto_key_handle,
+      GetCryptoKeyHandleFromOpenSslRsa(rsa), false);
+  KMSENGINE_ASSIGN_OR_RETURN_WITH_OPENSSL_ERROR(
+      const DigestCase digest_type,
+      ConvertOpenSslNidToDigestType(type), false);
+  KMSENGINE_ASSIGN_OR_RETURN_WITH_OPENSSL_ERROR(
+      const std::string digest_string,
+      MakeDigestString(digest_bytes, digest_length), false);
+
+  // Delegate handling of the signing operation to the backing layer.
+  KMSENGINE_ASSIGN_OR_RETURN_WITH_OPENSSL_ERROR(
+      const std::string signature,
+      crypto_key_handle->Sign(digest_type, digest_string), false);
+
+  // Copy results into the return pointers.
+  if (signature_return != nullptr) {
+    signature.copy(reinterpret_cast<char *>(signature_return),
+                   signature.length());
+  }
+  if (signature_length != nullptr) {
+    *signature_length = signature.length();
+  }
+  return true;
+}
+
+// Verifies that the signature `sigbuf` of size `siglen` matches the given
+// message digest `m` of size `m_len`. `type` denotes the message digest
+// algorithm that was used to generate the signature. `rsa` is the signer's
+// public key.
+//
+// Returns 1 on success; otherwise, returns 0.
+//
+// The function signature comes from the prototype for `RSA_meth_set_verify`
+// from the OpenSSL API.
+int Verify(int type, const unsigned char *m, unsigned int m_len,
+           const unsigned char *sigbuf, unsigned int siglen, const RSA *rsa) {
+  // TODO(https://github.com/googleinterns/cloud-kms-oss-tools/issues/101):
+  // This method is currently purposely left unimplemented, but it may need to
+  // be implemented at some point in the future.
+  KMSENGINE_SIGNAL_ERROR(
+      Status(StatusCode::kUnimplemented, "Unsupported operation"));
+  return false;
+}
+
+// Signs the `from_length` bytes in `from` using the RSA key `rsa` and stores
+// the signature in `to`. The caller is responsible for ensuring that `to`
+// points to `RSA_size(rsa)` bytes of memory. (See the OpenSSL man page for
+// RSA_private_encrypt(3) for more information.)
+//
+// According to the OpenSSL specification, `from` is usually a message
+// digest, but it doesn't have to be.
+//
+// Returns the length of `to` on success; otherwise, returns -1.
+//
+// The function signature comes from the prototype for `RSA_meth_set_priv_enc`
+// from the OpenSSL API.
+int PrivateEncrypt(int from_length, const unsigned char *from,
+                   unsigned char *to, RSA *rsa, int padding) {
+  // TODO(https://github.com/googleinterns/cloud-kms-oss-tools/issues/100): It
+  // may or may not be possible to simply redirect `PrivateEncrypt` to `Sign`.
+  KMSENGINE_SIGNAL_ERROR(
+      Status(StatusCode::kUnimplemented, "Unsupported operation"));
+  return -1;
+}
+
+// Recovers the message digest from the `from_length` bytes long signature in
+// `from` using the RSA key `rsa`. The caller is responsible for ensuring that
+// `to` points to a memory section large enough to hold the message digest
+// (which is smaller than `RSA_size(rsa) - 11`). `padding` is the padding mode
+// that was used to sign the data. (See the OpenSSL man page for
+// RSA_private_decrypt(3) for more information.)
+//
+// Returns the length of `to` on success; otherwise, returns -1.
+//
+// The function signature comes from the prototype for `RSA_meth_set_priv_dec`
+// from the OpenSSL API.
+int PrivateDecrypt(int from_length, const unsigned char *from,
+                   unsigned char *to, RSA *rsa, int padding) {
+  // TODO(https://github.com/googleinterns/cloud-kms-oss-tools/issues/102):
+  // Currently unimplemented on purpose, but can be defined when keys with the
+  // `ASYMMETRIC_DECRYPT` purpose should be supported by the engine.
+  KMSENGINE_SIGNAL_ERROR(
+      Status(StatusCode::kUnimplemented, "Unsupported operation"));
+  return -1;
+}
+
+}  // namespace
+
+OpenSslRsaMethod MakeKmsRsaMethod() {
+  OpenSslRsaMethod rsa_method = MakeRsaMethod(kRsaMethodName, kRsaMethodFlags);
+  if (rsa_method == nullptr) {
+    return OpenSslRsaMethod(nullptr, nullptr);
+  }
+
+  // `RSA_PKCS1_OpenSSL` returns the default OpenSSL `RSA_METHOD`
+  // implementation. We use it to "borrow" default implementations for public
+  // key-related operations, since the way those work should not change given
+  // that the engine has access to public key material.
+  const RSA_METHOD *openssl_rsa_method = RSA_PKCS1_OpenSSL();
+  if (// Public key operations can just reuse the OpenSSL defaults. This works
+      // because the engine key loader initializes `RSA` structs with all of
+      // the necessary public key material.
+      !RSA_meth_set_pub_enc(rsa_method.get(),
+                            RSA_meth_get_pub_enc(openssl_rsa_method)) ||
+      !RSA_meth_set_pub_dec(rsa_method.get(),
+                            RSA_meth_get_pub_dec(openssl_rsa_method)) ||
+      // There is no OpenSSL default for `verify`, so we need to implement it
+      // ourselves.
+      !RSA_meth_set_verify(rsa_method.get(), Verify) ||
+      // Private key operations need to be implemented by our engine.
+      !RSA_meth_set_priv_dec(rsa_method.get(), PrivateDecrypt) ||
+      !RSA_meth_set_priv_enc(rsa_method.get(), PrivateEncrypt) ||
+      !RSA_meth_set_sign(rsa_method.get(), Sign) ||
+      // Memory initialization and cleanup functions.
+      !RSA_meth_set_init(rsa_method.get(), Init) ||
+      !RSA_meth_set_finish(rsa_method.get(), Finish) ||
+      // `mod_exp` and `bn_mod_exp` are called by the default OpenSSL RSA
+      // method. The OpenSSL man page for RSA_set_method(3) explicitly
+      // permits these callbacks to be set to null in an engine implementation.
+      // However, we are defining them here to be the OpenSSL defaults since
+      // the OpenSSL command-line utilities apparently require them to be
+      // defined in order for verification operations to work.
+      !RSA_meth_set_mod_exp(rsa_method.get(),
+                            RSA_meth_get_mod_exp(openssl_rsa_method)) ||
+      !RSA_meth_set_bn_mod_exp(rsa_method.get(),
+                               RSA_meth_get_bn_mod_exp(openssl_rsa_method)) ||
+      // `keygen` is NULL since key management functions are out of scope of
+      // the Cloud KMS engine. The OpenSSL man page for RSA_set_method(3)
+      // explicitly permits this callback to be set to null in an engine
+      // implementation.
+      !RSA_meth_set_keygen(rsa_method.get(), nullptr)) {
+    return OpenSslRsaMethod(nullptr, nullptr);
+  }
+
+  return rsa_method;
+}
+
+}  // namespace crypto
+}  // namespace bridge
+}  // namespace kmsengine

--- a/src/bridge/crypto/rsa.cc
+++ b/src/bridge/crypto/rsa.cc
@@ -153,7 +153,7 @@ int Sign(int type, const unsigned char *digest_bytes,
   }
   if (signature_return != nullptr) {
     // Sanity check on `RSA_size` and the length of the signature.
-    auto rsa_size = RSA_size(rsa);
+    int rsa_size = RSA_size(rsa);
     if (rsa_size < 0) {
       KMSENGINE_SIGNAL_ERROR(Status(StatusCode::kFailedPrecondition,
                                     "RSA_size(rsa) was < 0"));

--- a/src/bridge/crypto/rsa.h
+++ b/src/bridge/crypto/rsa.h
@@ -20,41 +20,15 @@
 #include <openssl/rsa.h>
 
 #include "src/bridge/memory_util/openssl_structs.h"
+#include "src/backing/status/status_or.h"
 
 namespace kmsengine {
 namespace bridge {
 namespace crypto {
 
-// A human-readable name associated with the Cloud KMS engine's RSA_METHOD.
-//
-// Used by some OpenSSL-backed applications.
-constexpr char kRsaMethodName[] = "Google Cloud KMS RSA Method";
-
-// Bitwise mask of OpenSSL flags to associate with the Cloud KMS engine's
-// RSA_METHOD. See `rsa.h` from OpenSSL for flag definitions.
-//
-// The flags that are currently set are:
-//
-//  - RSA_FLAG_EXT_PKEY: This flag means that the private key material
-//    normally stored within an OpenSSL RSA struct does not exist. Our
-//    engine operates on Cloud KMS keys, so this flag is set. See
-//    RSA_new_method(3) for more information.
-//
-//  - RSA_METHOD_FLAG_NO_CHECK: Tells OpenSSL that the key material stored in
-//    the RSA struct may not contain both private and public key information
-//    (this is the case due to the fact that the engine does not have access to
-//    Cloud KMS private key material) and thus it should not check that the
-//    private and public key form a valid pair.
-//
-//    RSA_new_method(3) documents the existence of the RSA_METHOD_FLAG_NO_CHECK
-//    flag, but see https://github.com/openssl/openssl/pull/2243 for a more
-//    detailed explanation.
-//
-constexpr int kRsaMethodFlags = RSA_FLAG_EXT_PKEY | RSA_METHOD_FLAG_NO_CHECK;
-
 // Allocates memory for and initializes an OpenSSL `RSA_METHOD` struct with
 // pointers to the Cloud KMS engine RSA implementations.
-OpenSslRsaMethod MakeKmsRsaMethod();
+StatusOr<OpenSslRsaMethod> MakeKmsRsaMethod();
 
 }  // namespace crypto
 }  // namespace bridge

--- a/src/bridge/crypto/rsa.h
+++ b/src/bridge/crypto/rsa.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef KMSENGINE_BRIDGE_CRYPTO_RSA_H_
+#define KMSENGINE_BRIDGE_CRYPTO_RSA_H_
+
+#include <openssl/rsa.h>
+
+#include "src/bridge/memory_util/openssl_structs.h"
+
+namespace kmsengine {
+namespace bridge {
+namespace crypto {
+
+// A human-readable name associated with the Cloud KMS engine's RSA_METHOD.
+//
+// Used by some OpenSSL-backed applications.
+constexpr char kRsaMethodName[] = "Google Cloud KMS RSA Method";
+
+// Bitwise mask of OpenSSL flags to associate with the Cloud KMS engine's
+// RSA_METHOD. See `rsa.h` from OpenSSL for flag definitions.
+//
+// The flags that are currently set are:
+//
+//  - RSA_FLAG_EXT_PKEY: This flag means that the private key material
+//    normally stored within an OpenSSL RSA struct does not exist. Our
+//    engine operates on Cloud KMS keys, so this flag is set.
+//
+constexpr int kRsaMethodFlags = RSA_FLAG_EXT_PKEY | RSA_METHOD_FLAG_NO_CHECK;
+
+// Allocates memory for and initializes an OpenSSL `RSA_METHOD` struct with
+// pointers to the Cloud KMS engine RSA implementations.
+OpenSslRsaMethod MakeKmsRsaMethod();
+
+}  // namespace crypto
+}  // namespace bridge
+}  // namespace kmsengine
+
+#endif  // KMSENGINE_BRIDGE_CRYPTO_RSA_H_

--- a/src/bridge/crypto/rsa.h
+++ b/src/bridge/crypto/rsa.h
@@ -37,7 +37,18 @@ constexpr char kRsaMethodName[] = "Google Cloud KMS RSA Method";
 //
 //  - RSA_FLAG_EXT_PKEY: This flag means that the private key material
 //    normally stored within an OpenSSL RSA struct does not exist. Our
-//    engine operates on Cloud KMS keys, so this flag is set.
+//    engine operates on Cloud KMS keys, so this flag is set. See
+//    RSA_new_method(3) for more information.
+//
+//  - RSA_METHOD_FLAG_NO_CHECK: Tells OpenSSL that the key material stored in
+//    the RSA struct may not contain both private and public key information
+//    (this is the case due to the fact that the engine does not have access to
+//    Cloud KMS private key material) and thus it should not check that the
+//    private and public key form a valid pair.
+//
+//    RSA_new_method(3) documents the existence of the RSA_METHOD_FLAG_NO_CHECK
+//    flag, but see https://github.com/openssl/openssl/pull/2243 for a more
+//    detailed explanation.
 //
 constexpr int kRsaMethodFlags = RSA_FLAG_EXT_PKEY | RSA_METHOD_FLAG_NO_CHECK;
 

--- a/src/bridge/crypto/rsa_test.cc
+++ b/src/bridge/crypto/rsa_test.cc
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+#include <string>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <openssl/engine.h>
+#include <openssl/rsa.h>
+
+#include "src/bridge/ex_data_util/ex_data_util.h"
+#include "src/bridge/memory_util/openssl_structs.h"
+#include "src/bridge/crypto/rsa.h"
+#include "src/testing_util/mock_crypto_key_handle.h"
+#include "src/testing_util/openssl_assertions.h"
+#include "src/testing_util/test_matchers.h"
+
+namespace kmsengine {
+namespace bridge {
+namespace crypto {
+namespace {
+
+using ::kmsengine::testing_util::IsOk;
+using ::kmsengine::testing_util::MockCryptoKeyHandle;
+using ::testing::IsNull;
+using ::testing::NotNull;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::HasSubstr;
+
+// Test fixture for calling initialization functions (normally called by the
+// `EngineBind` function) needed for the RSA callbacks to work.
+class RsaMethodTest : public ::testing::Test {
+ protected:
+  RsaMethodTest() : rsa_method_(MakeKmsRsaMethod()) {}
+
+  void SetUp() override {
+    ASSERT_THAT(InitExternalIndices(), IsOk());
+    ASSERT_THAT(rsa_method(), NotNull());
+  }
+
+  void TearDown() override {
+    FreeExternalIndices();
+  }
+
+  // Convenience function for making an RSA struct with the Cloud KMS RSA_METHOD
+  // implementation already attached.
+  OpenSslRsa MakeRsaWithKmsMethod() {
+    auto rsa = MakeRsa();
+    if (rsa) RSA_set_method(rsa.get(), rsa_method());
+    return rsa;
+  }
+
+  RSA_METHOD *rsa_method() { return rsa_method_.get(); }
+
+ private:
+  OpenSslRsaMethod rsa_method_;
+};
+
+TEST_F(RsaMethodTest, RsaMethodCallbacksAreInitialized) {
+  // The OpenSSL specification does not explicitly permit these RSA operations
+  // to be null, so we check to make sure that they're defined.
+  //
+  // The other operations (`mod_exp`, `bn_mod_exp`, and `keygen`) may be null
+  // according to the OpenSSL specification (but they may also be defined).
+  EXPECT_THAT(RSA_meth_get_pub_enc(rsa_method()), NotNull());
+  EXPECT_THAT(RSA_meth_get_pub_dec(rsa_method()), NotNull());
+  EXPECT_THAT(RSA_meth_get_verify(rsa_method()), NotNull());
+  EXPECT_THAT(RSA_meth_get_priv_dec(rsa_method()), NotNull());
+  EXPECT_THAT(RSA_meth_get_priv_enc(rsa_method()), NotNull());
+  EXPECT_THAT(RSA_meth_get_sign(rsa_method()), NotNull());
+  EXPECT_THAT(RSA_meth_get_init(rsa_method()), NotNull());
+  EXPECT_THAT(RSA_meth_get_finish(rsa_method()), NotNull());
+}
+
+TEST_F(RsaMethodTest, FinishCleansUpCryptoKeyHandle) {
+  // Using `RSA_new` instead of `MakeRsa` here so we can explicitly call
+  // `RSA_free` at the end to test that the mock got cleaned up.
+  RSA *rsa = RSA_new();
+  ASSERT_THAT(rsa, NotNull());
+  RSA_set_method(rsa, rsa_method());
+
+  // If mocks aren't deleted before the end of a test, an error is raised.
+  // Thus, if `RSA_free` doesn't delete the underlying `CryptoKeyHandle`, then
+  // this test will fail.
+  auto handle = new MockCryptoKeyHandle();
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(handle, rsa), IsOk());
+
+  RSA_free(rsa);
+}
+
+TEST_F(RsaMethodTest, SignReturnsSignature) {
+  // Construct the RSA struct within the test body as opposed to the fixture
+  // so it cleans itself up before the end of the test. This is important so
+  // that it deletes the `MockCryptoKeyHandle` before the test body ends
+  // (otherwise a testing error will be raised).
+  OpenSslRsa rsa = MakeRsaWithKmsMethod();
+  ASSERT_THAT(rsa, NotNull());
+
+  std::string expected = "my signature";
+  auto handle = new MockCryptoKeyHandle();
+  EXPECT_CALL(*handle, Sign).WillOnce(Return(StatusOr<std::string>(expected)));
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(handle, rsa.get()), IsOk());
+
+  std::string digest = "sample digest";
+  unsigned char signature[expected.length()];
+  unsigned int signature_length;
+  ASSERT_OPENSSL_SUCCESS(
+      RSA_sign(NID_sha256, reinterpret_cast<unsigned char *>(&digest[0]),
+               digest.length(), signature, &signature_length, rsa.get()));
+
+  std::string actual(reinterpret_cast<char *>(signature), signature_length);
+  EXPECT_THAT(actual, StrEq(expected));
+}
+
+TEST_F(RsaMethodTest, SignHandlesCryptoKeyHandleSignMethodErrors) {
+  OpenSslRsa rsa = MakeRsaWithKmsMethod();
+  ASSERT_THAT(rsa, NotNull());
+
+  auto expected_error_message = "mock CryptoKeyHandle::Sign failed";
+  auto handle = new MockCryptoKeyHandle();
+  EXPECT_CALL(*handle, Sign).WillOnce(Return(StatusOr<std::string>(
+      Status(StatusCode::kInternal, expected_error_message))));
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(handle, rsa.get()), IsOk());
+
+  std::string digest = "sample digest";
+  EXPECT_OPENSSL_FAILURE(
+      RSA_sign(NID_sha256, reinterpret_cast<unsigned char *>(&digest[0]),
+               digest.length(), nullptr, nullptr, rsa.get()),
+      HasSubstr(expected_error_message));
+}
+
+TEST_F(RsaMethodTest, SignHandlesMissingCryptoKeyHandle) {
+  OpenSslRsa rsa = MakeRsaWithKmsMethod();
+  ASSERT_THAT(rsa, NotNull());
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(nullptr, rsa.get()), IsOk());
+
+  std::string digest = "sample digest";
+  EXPECT_OPENSSL_FAILURE(
+      RSA_sign(NID_sha256, reinterpret_cast<unsigned char *>(&digest[0]),
+               digest.length(), nullptr, nullptr, rsa.get()),
+      HasSubstr("RSA instance was not initialized with Cloud KMS data"));
+}
+
+TEST_F(RsaMethodTest, SignHandlesBadNidDigestTypes) {
+  OpenSslRsa rsa = MakeRsaWithKmsMethod();
+  ASSERT_THAT(rsa, NotNull());
+
+  auto handle = new MockCryptoKeyHandle();
+  EXPECT_CALL(*handle, Sign).Times(0);
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(handle, rsa.get()), IsOk());
+
+  // Use MD5 as our "bad digest type" example, since it's not supported by
+  // Cloud KMS (and since it's an insecure algorithm, it probably won't be
+  // supported in the future).
+  constexpr auto kBadDigestType = NID_md5;
+  std::string digest = "sample digest";
+  EXPECT_OPENSSL_FAILURE(
+      RSA_sign(kBadDigestType, reinterpret_cast<unsigned char *>(&digest[0]),
+               digest.length(), nullptr, nullptr, rsa.get()),
+      HasSubstr("Unsupported digest type"));
+}
+
+}  // namespace
+}  // namespace crypto
+}  // namespace bridge
+}  // namespace kmsengine

--- a/src/bridge/crypto/rsa_test.cc
+++ b/src/bridge/crypto/rsa_test.cc
@@ -276,7 +276,8 @@ TEST_F(RsaMethodTest, SignHandlesSignatureLongerThanRsaSize) {
       RSA_sign(NID_sha256, reinterpret_cast<unsigned char *>(&digest[0]),
                digest.length(), signature, &signature_length,
                rsa.get()),
-      HasSubstr("Generated signature length was larger than RSA_size(rsa)"));
+      HasSubstr("Generated signature length was unexpectedly larger than "
+                "RSA_size(rsa)"));
 }
 
 }  // namespace

--- a/src/bridge/crypto/rsa_test.cc
+++ b/src/bridge/crypto/rsa_test.cc
@@ -48,9 +48,13 @@ const std::string kSampleSignature = "my signature";
 // `EngineBind` function) needed for the RSA callbacks to work.
 class RsaMethodTest : public ::testing::Test {
  protected:
-  RsaMethodTest() : rsa_method_(MakeKmsRsaMethod()) {}
+  RsaMethodTest() : rsa_method_(nullptr, nullptr) {}
 
   void SetUp() override {
+    StatusOr<OpenSslRsaMethod> kms_rsa_method_or = MakeKmsRsaMethod();
+    ASSERT_THAT(kms_rsa_method_or, IsOk());
+    rsa_method_ = std::move(kms_rsa_method_or.value());
+
     ASSERT_THAT(InitExternalIndices(), IsOk());
     ASSERT_THAT(rsa_method(), NotNull());
   }

--- a/src/bridge/crypto/rsa_test.cc
+++ b/src/bridge/crypto/rsa_test.cc
@@ -199,6 +199,21 @@ TEST_F(RsaMethodTest, SignHandlesNullSignatureLengthPointer) {
       HasSubstr("Signature length parameter may not be null"));
 }
 
+TEST_F(RsaMethodTest, SignHandlesNullSignatureAndNullLengthPointer) {
+  StatusOr<OpenSslRsa> rsa_or = MakeRsaWithKmsMethod();
+  ASSERT_THAT(rsa_or, IsOk());
+  OpenSslRsa rsa = std::move(rsa_or.value());
+
+  MockCryptoKeyHandle *handle = new MockCryptoKeyHandle();
+  ASSERT_THAT(AttachCryptoKeyHandleToOpenSslRsa(handle, rsa.get()), IsOk());
+
+  std::string digest = "my digest";
+  EXPECT_OPENSSL_FAILURE(
+      RSA_sign(NID_sha256, reinterpret_cast<unsigned char *>(&digest[0]),
+               digest.length(), nullptr, nullptr, rsa.get()),
+      HasSubstr("Signature length parameter may not be null"));
+}
+
 TEST_F(RsaMethodTest, SignHandlesCryptoKeyHandleSignMethodErrors) {
   StatusOr<OpenSslRsa> rsa_or = MakeRsaWithKmsMethod();
   ASSERT_THAT(rsa_or, IsOk());

--- a/src/bridge/error/error.h
+++ b/src/bridge/error/error.h
@@ -111,4 +111,23 @@ int GetErrorLibraryId();
     __lhs, __rhs, __return,                                                   \
     __KMSENGINE_MACRO_CONCAT(__status_or_value, __COUNTER__))
 
+// Convenience wrapper around `KMSENGINE_SIGNAL_ERROR` that emulates the
+// `KMSENGINE_RETURN_IF_ERROR` macro, but for OpenSSL callbacks.
+//
+// Early-returns `__return` if `__status` is an error `Status`; otherwise,
+// proceeds.
+//
+// `__return` is not hard-coded since the OpenSSL callbacks that the engine
+// needs to implement have different failure return values.
+//
+// The argument expression is guaranteed to be evaluated exactly once.
+#define KMSENGINE_RETURN_IF_OPENSSL_ERROR(__status, __return) \
+  do {                                                        \
+    auto status = __status;                                   \
+    if (!status.ok()) {                                       \
+      KMSENGINE_SIGNAL_ERROR(status);                         \
+      return __return;                                        \
+    }                                                         \
+  } while (false)
+
 #endif  // KMSENGINE_BRIDGE_ERROR_ERROR_H_


### PR DESCRIPTION
Resolves #14.

I'm documenting the PSS padding TODO in a separate issue.

Test case fixture here isn't ideal---the `MakeRsaWithKmsMethod` call must be done within the test body otherwise it isn't cleared before expectations on mocks are checked at the end of the test body, which results in some memory leak failures according to GMock. Tried to figure out a good way around this, but not really sure as of the moment.