### PR TITLE
Ensure bridge layer is being built statically

### DIFF
--- a/src/BUILD
+++ b/src/BUILD
@@ -14,16 +14,4 @@
 # limitations under the License.
 #
 
-load("@rules_cc//cc:defs.bzl", "cc_binary")
-
-package(default_visibility = ["//test:__subpackages__"])
-
-cc_binary(
-    name = "libengine.so",
-    linkopts = ["-lcrypto"],
-    linkshared = 1,  # Build as a shared object.
-    linkstatic = 0,
-    deps = [
-        "//src/bridge",
-    ],
-)
+# File is purposely blank to allow for `bazel build //src:...` to work.

--- a/src/bridge/BUILD
+++ b/src/bridge/BUILD
@@ -14,15 +14,22 @@
 # limitations under the License.
 #
 
-load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
-package(default_visibility = ["//src:__subpackages__"])
+package(default_visibility = ["//src/bridge:__subpackages__"])
 
-cc_library(
-    name = "bridge",
+cc_binary(
+    name = "libengine.so",
     srcs = ["main.c"],
     linkopts = ["-lcrypto"],
-    deps = ["//src/bridge:engine_bind"],
+    linkshared = 1,
+    linkstatic = 1,
+    visibility = ["//test:__subpackages__"],
+    deps = [
+        "//src/bridge:engine_bind",
+        "//src/bridge:engine_name",
+        "//src/bridge:engine_setup",
+    ],
 )
 
 cc_library(

--- a/test/openssl_cli/BUILD
+++ b/test/openssl_cli/BUILD
@@ -24,6 +24,6 @@ sh_test(
     name = "load_engine_test",
     size = "small",
     srcs = ["load_engine_test.sh"],
-    args = ["$(rootpath //src:libengine.so)"],
-    data = ["//src:libengine.so"],
+    args = ["$(rootpath //src/bridge:libengine.so)"],
+    data = ["//src/bridge:libengine.so"],
 )


### PR DESCRIPTION
Resolves #116.

The bridge layer should be built as a fully static library (except for including the bridge layer .so). This PR fixes that (was separated from another PR).

The reason why `libengine.so` is being moved into `/src/bridge` instead of remaining at `/src` is because `cc_binary` needs to be given the actual file for `main.c` (not a dependency containing `main.c`); otherwise it doesn't actually include the symbol definition. This is a Bazel quirk related to the "hacky magic" documented in #56.