### PR TITLE
Add OpenSSL engine installation guide to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,93 @@ implementation. This allows, for example, an HTTPS web server that uses OpenSSL
 to make use of a private key that is protected by and never leaves an HSM 
 running on Google Cloud Platform.
 
+### Installation
+
+Installation guide has been tested on a Debian GNU/Linux 9 distribution.
+
+1. Set up a [Google Cloud service account][service-account] with the [`roles/cloudkms/signerVerifier`][roles] permission. Then, follow one of the authentication flows at ["Authenticating as a service account"][service-account] to authenticate your engine environment with the service account's credentials.
+
+2. Install Git, Bazel, and the OpenSSL `libcrypto.so` libraries. On Debian, you can use the following commands:
+
+    ```bash
+    # Install Git and Bazel dependencies.
+    sudo apt-get -y install git-all curl gnupg
+    # Install Bazel.
+    curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+    echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+    sudo apt-get update && sudo apt-get -y install bazel
+    # Install libcrypto.so.
+    sudo apt-get -y install libssl-dev
+    ```
+
+3. Clone repository and build with Bazel.
+
+    ```bash
+    git clone https://github.com/googleinterns/cloud-kms-oss-tools.git
+    cd cloud-kms-oss-tools/src
+    bazel build ...
+    ```
+
+    The engine libraries are now located in `cloud-kms-oss-tools/bazel-bin/src/bridge/libengine.so` and `cloud-kms-oss-tools/bazel-bin/src/backing/libkms.so`.
+    
+    _Optional:_ Run all of the Bazel tests.
+    
+    ```bash
+    bazel test ...
+    ```
+  
+4. Add the engine to the OpenSSL configuration file, `openssl.cnf`. You can find the directory containing the OpenSSL configuration by running `openssl version -d`.
+
+    ```bash
+    $ openssl version -d
+    OPENSSLDIR: "/usr/lib/ssl"
+    $ sudo vim /usr/lib/ssl/openssl.cnf
+    ```
+    
+    If `openssl.cnf` does not already define an `openssl_conf` section (some distributions will already define it), define it at the top-level of the configuration. For example, this line defines `openssl_conf` to point to the `openssl_init` section:
+    
+    ```
+    openssl_conf = openssl_init
+    ```
+
+    At the bottom of the configuration file, add the `openssl_init` section and add the engine configuration for the `gcloudkms` engine:
+
+    ```
+    [ openssl_init ]
+    engines = engine_section
+
+    [ engine_section ]
+    gcloudkms = gcloudkms_section
+
+    [ gcloudkms_section ]
+    dynamic_path = /my/path/to/bazel-bin/src/bridge/libengine.so  # Update as needed
+    default_algorithms = ALL
+    ```
+    
+5. Test that OpenSSL can find the engine by running `openssl engine`. `gcloudkms` should appear in the list.
+
+    ```bash
+    $ openssl engine
+    (rdrand) Intel RDRAND engine
+    (dynamic) Dynamic engine loading support
+    (gcloudkms) Google Cloud KMS Engine
+    ```
+    
+    Test that OpenSSL can dynamically load the engine by running `openssl engine -t gcloudkms`:
+    
+    ```bash
+    $ openssl engine -t gcloudkms
+    (gcloudkms) Google Cloud KMS Engine
+         [ available ]
+    ```
+    
+    If `available` appears, the engine is ready to be used.
+
 [kms]: https://cloud.google.com/kms
 [hsm]: https://cloud.google.com/hsm
 [openssl-engine]: 
 https://raw.githubusercontent.com/openssl/openssl/master/README.ENGINE
+[service-account]:
+https://cloud.google.com/docs/authentication/production
+[roles]:
+https://cloud.google.com/kms/docs/reference/permissions-and-roles#predefined


### PR DESCRIPTION
Resolves #25.

As a last PR---this adds a quick Debian installation guide to the README as to how to add the engine to the OpenSSL utility. Web server usage is not definite at the moment, in part and so I've just been documenting that informally in the issues. 